### PR TITLE
Update cloned dir to match new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Development
 -----------
 
     % git clone git://github.com/LibraryOfCongress/bagit-python.git
-    % cd bagit 
+    % cd bagit-python
     % python test.py
 
 If you'd like to see how increasing parallelization of bag creation on 


### PR DESCRIPTION
Just spotted this while updating a fork - seemed as quick to apply a patch as raise an issue.
