### PR TITLE
Update repo name and cloned dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ except bag.BagValidationError, e:
 Development
 -----------
 
-    % git clone git://github.com/libraryofcongress/bagit.git
-    % cd bagit 
+    % git clone git://github.com/LibraryOfCongress/bagit-python.git
+    % cd bagit-python
     % python test.py
 
 If you'd like to see how increasing parallelization of bag creation on 


### PR DESCRIPTION
Looks like b450ced1fb merged incorrect repo location back in. Also update the cloned dir to match new repo name.
