### PR TITLE
logging namespace cleanup

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -44,6 +44,8 @@ from glob import glob
 from datetime import date
 from itertools import chain
 
+logger = logging.getLogger(__name__)
+
 # standard bag-info.txt metadata
 _bag_info_headers = [
     'Source-Organization',


### PR DESCRIPTION
This is a really trivial cleanup item, but it makes it nicer to use the bagit-python package when importing and using as a module, so that logging can be controlled separately from other modules.
