### PR TITLE
fixing broken test that asserted wrong sha1 hash

### DIFF
--- a/test.py
+++ b/test.py
@@ -272,7 +272,7 @@ class TestSingleProcessValidation(unittest.TestCase):
     def test_sha1_tagfile(self):
         bag = bagit.make_bag(self.tmpdir, checksum=['sha1'])
         self.assertTrue(os.path.isfile(j(self.tmpdir, 'tagmanifest-sha1.txt')))
-        self.assertEqual(bag.entries['bag-info.txt']['sha1'], 'b537642e07abc0c22c428aee65180e97f78e61dc')
+        self.assertEqual(bag.entries['bag-info.txt']['sha1'], 'a55b819e08b1de926b3d70a65a6e0ffd35269b56')
         
     def test_validate_unreadable_file(self):
         bag = bagit.make_bag(self.tmpdir, checksum=["md5"])


### PR DESCRIPTION
The sha1 hash specified in the test is wrong. This updates and fixes it so that Jenkins can build correctly.
