### PR TITLE
Ensure fetch.txt gets processed as a tag file and not a payload file …

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -111,6 +111,8 @@ def make_bag(bag_dir, bag_info=None, processes=1, checksum=None):
             temp_data = tempfile.mkdtemp(dir=cwd)
 
             for f in os.listdir('.'):
+                if f == 'fetch.txt':
+                    continue
                 if os.path.abspath(f) == temp_data:
                     continue
                 new_f = os.path.join(temp_data, f)


### PR DESCRIPTION
…if found when creating a new bag.

If I provide a fetch.txt tag file in my bag directory, it is treated as a payload file and placed in the data directory rather than being treated as an optional tag file as the spec outlines.  In the current code, how am I supposed to provide a fetch.txt file during bag creation so that this does not happen?  

This pull request contains my simple solution for getting around this.  Is this sufficient or are there other considerations. Please advise.