### PR TITLE
Explicit encoding management 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.tox
+__pycache__
+dist
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.pyc
-*.log
 bench-data
 build
 dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ python:
  - "3.4"
  - "3.5"
 script: python setup.py test
+
+install:
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.5
+RUN mkdir /bagit
+WORKDIR /bagit
+COPY .git/ /bagit/.git/
+COPY *.py /bagit/
+COPY test-data /bagit/test-data/
+CMD [ "python", "setup.py", "test" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.5
-RUN mkdir /bagit
+RUN useradd --user-group bagit-tester
+RUN install -d -o bagit-tester /bagit
+USER bagit-tester
 WORKDIR /bagit
 COPY .git/ /bagit/.git/
 COPY *.py /bagit/

--- a/bagit.py
+++ b/bagit.py
@@ -219,7 +219,7 @@ class Bag(object):
 
         info_file_path = os.path.join(self.path, self.tag_file_name)
         if os.path.exists(info_file_path):
-            self.info = _load_tag_file(info_file_path)
+            self.info = _load_tag_file(info_file_path, encoding=self.encoding)
 
         self._load_manifests()
 
@@ -401,7 +401,7 @@ class Bag(object):
             alg = os.path.basename(manifest_file).replace(search, "").replace(".txt", "")
             self.algs.append(alg)
 
-            with open_text_file(manifest_file, 'r', encoding='utf-8-sig') as manifest_file:
+            with open_text_file(manifest_file, 'r', encoding=self.encoding) as manifest_file:
                 for line in manifest_file:
                     line = line.strip()
 
@@ -671,8 +671,8 @@ def _calculate_file_hashes(full_path, f_hashers):
     )
 
 
-def _load_tag_file(tag_file_name):
-    with open_text_file(tag_file_name, 'r', encoding='utf-8-sig') as tag_file:
+def _load_tag_file(tag_file_name, encoding='utf-8-sig'):
+    with open_text_file(tag_file_name, 'r', encoding=encoding) as tag_file:
         # Store duplicate tags as list of vals
         # in order of parsing under the same key.
         tags = {}

--- a/bagit.py
+++ b/bagit.py
@@ -584,8 +584,8 @@ class BagValidationError(BagError):
 
     def __str__(self):
         if len(self.details) > 0:
-            details = u" ; ".join([force_unicode(e) for e in self.details])
-            return u"%s: %s" % (self.message, details)
+            details = " ; ".join([force_unicode(e) for e in self.details])
+            return "%s: %s" % (self.message, details)
         return self.message
 
 
@@ -662,9 +662,9 @@ def _calculate_file_hashes(full_path, f_hashers):
                 for i in f_hashers.values():
                     i.update(block)
     except IOError as e:
-        raise BagValidationError(u"could not read %s: %s" % (full_path, force_unicode(e)))
+        raise BagValidationError("could not read %s: %s" % (full_path, force_unicode(e)))
     except OSError as e:
-        raise BagValidationError(u"could not read %s: %s" % (full_path, force_unicode(e)))
+        raise BagValidationError("could not read %s: %s" % (full_path, force_unicode(e)))
 
     return dict(
         (alg, h.hexdigest()) for alg, h in f_hashers.items()

--- a/bagit.py
+++ b/bagit.py
@@ -79,9 +79,9 @@ STANDARD_BAG_INFO_HEADERS = [
 
 CHECKSUM_ALGOS = ['md5', 'sha1', 'sha256', 'sha512']
 
-#: Convenience function used everywhere we want to open
-#: a file to read text rather than undecoded bytes.
-open_text_file = partial(codecs.open, encoding='utf-8')
+#: Convenience function used everywhere we want to open a file to read text
+#: rather than undecoded bytes:
+open_text_file = partial(codecs.open, encoding='utf-8', errors='strict')
 
 
 def make_bag(bag_dir, bag_info=None, processes=1, checksum=None):

--- a/bagit.py
+++ b/bagit.py
@@ -214,7 +214,9 @@ class Bag(object):
         else:
             raise BagError("Unsupported bag version: %s" % self.version)
 
-        if not self.encoding.lower() == "utf-8":
+        try:
+            codecs.lookup(self.encoding)
+        except codecs.LookupError:
             raise BagValidationError("Unsupported encoding: %s" % self.encoding)
 
         info_file_path = os.path.join(self.path, self.tag_file_name)

--- a/bagit.py
+++ b/bagit.py
@@ -46,7 +46,6 @@ import sys
 import tempfile
 from datetime import date
 from functools import partial
-from os import listdir
 from os.path import abspath, isdir, isfile, join
 from pkg_resources import DistributionNotFound, get_distribution
 
@@ -806,9 +805,10 @@ def _find_tag_files(bag_dir):
                 for filename in filenames:
                     if filename.startswith('tagmanifest-'):
                         continue
-                    #remove everything up to the bag_dir directory
+                    # remove everything up to the bag_dir directory
                     p = join(dir_name, filename)
                     yield os.path.relpath(p, bag_dir)
+
 
 def _walk(data_dir):
     for dirpath, dirnames, filenames in os.walk(data_dir):
@@ -922,6 +922,7 @@ else:
 
 # following code is used for command line program
 
+
 class BagArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
         self.bag_info = {}
@@ -938,7 +939,7 @@ class BagHeaderAction(argparse.Action):
 def _make_parser():
     parser = BagArgumentParser(description='bagit-python version %s' % VERSION)
     parser.add_argument('--processes', type=int, dest='processes', default=1,
-                      help='parallelize checksums generation and verification')
+                        help='parallelize checksums generation and verification')
     parser.add_argument('--log', help='The name of the log file')
     parser.add_argument('--quiet', action='store_true')
     parser.add_argument('--validate', action='store_true')
@@ -947,17 +948,16 @@ def _make_parser():
     # optionally specify which checksum algorithm(s) to use when creating a bag
     # NOTE: could generate from checksum_algos ?
     parser.add_argument('--md5', action='append_const', dest='checksum', const='md5',
-                      help='Generate MD5 manifest when creating a bag (default)')
+                        help='Generate MD5 manifest when creating a bag (default)')
     parser.add_argument('--sha1', action='append_const', dest='checksum', const='sha1',
-                      help='Generate SHA1 manifest when creating a bag')
+                        help='Generate SHA1 manifest when creating a bag')
     parser.add_argument('--sha256', action='append_const', dest='checksum', const='sha256',
-                      help='Generate SHA-256 manifest when creating a bag')
+                        help='Generate SHA-256 manifest when creating a bag')
     parser.add_argument('--sha512', action='append_const', dest='checksum', const='sha512',
-                      help='Generate SHA-512 manifest when creating a bag')
+                        help='Generate SHA-512 manifest when creating a bag')
 
     for header in STANDARD_BAG_INFO_HEADERS:
-        parser.add_argument('--%s' % header.lower(), type=str,
-                          action=BagHeaderAction)
+        parser.add_argument('--%s' % header.lower(), type=str, action=BagHeaderAction)
 
     parser.add_argument('directory', nargs='+', help='directory to make a bag from')
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,9 @@
-from sys import exit, version
-
+import sys
 from setuptools import setup
 
-import bagit
-
-if version < '2.6.0':
-    print("python 2.6 or higher is required")
-    exit(1)
+if sys.version_info < (2, 6):
+    print("Python 2.6 or higher is required")
+    sys.exit(1)
 
 description = \
 """
@@ -26,7 +23,10 @@ try:
 except:
     requirements.append("hashlib")
 
-version = bagit.VERSION
+tests_require = ['mock']
+
+if sys.version_info < (2, 7):
+    tests_require.append('unittest2')
 
 setup(
     name = 'bagit',
@@ -40,7 +40,7 @@ setup(
     platforms = ['POSIX'],
     test_suite = 'test',
     setup_requires=['setuptools_scm'],
-    tests_require=['mock'],
+    tests_require=tests_require,
     install_requires = requirements,
     classifiers = [
         'License :: Public Domain',

--- a/test.py
+++ b/test.py
@@ -15,6 +15,9 @@ import tempfile
 import unittest
 from os.path import join as j
 
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+
 import bagit
 import mock
 

--- a/test.py
+++ b/test.py
@@ -572,9 +572,9 @@ Tag-File-Character-Encoding: UTF-8
         self.assertEqual(bag.info["test"], "foobar")
 
     def test_unicode_in_tags(self):
-        bag = bagit.make_bag(self.tmpdir, {"test": u'♡'})
+        bag = bagit.make_bag(self.tmpdir, {"test": '♡'})
         bag = bagit.Bag(self.tmpdir)
-        self.assertEqual(bag.info['test'], u'♡')
+        self.assertEqual(bag.info['test'], '♡')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -15,11 +15,11 @@ import tempfile
 import unittest
 from os.path import join as j
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-
 import bagit
 import mock
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
 
 logging.basicConfig(filename='test.log', level=logging.DEBUG)
 stderr = logging.StreamHandler()
@@ -433,8 +433,8 @@ class TestBag(unittest.TestCase):
             'data/si/4011399822_65987a4806_b_d.jpg',
             'data/loc/2478433644_2839c5e8b8_o_d.jpg',
             'data/loc/3314493806_6f1db86d66_o_d.jpg']))
-        self.assertEqual(list(bag.manifest_files()), ['%s/manifest-md5.txt' %
-            self.tmpdir])
+        self.assertEqual(list(bag.manifest_files()),
+                         ['%s/manifest-md5.txt' % self.tmpdir])
 
     def test_has_oxum(self):
         bag = bagit.make_bag(self.tmpdir)

--- a/test.py
+++ b/test.py
@@ -21,9 +21,13 @@ if sys.version_info < (2, 7):
 import bagit
 import mock
 
-# don't let < ERROR clutter up test output
-logging.basicConfig(filename="test.log", level=logging.DEBUG)
+logging.basicConfig(filename='test.log', level=logging.DEBUG)
+stderr = logging.StreamHandler()
+stderr.setLevel(logging.WARNING)
+logging.getLogger().addHandler(stderr)
 
+# But we do want any exceptions raised in the logging path to be raised:
+logging.raiseExceptions = True
 
 @mock.patch('bagit.VERSION', new='1.5.4')  # This avoids needing to change expected hashes on each release
 class TestSingleProcessValidation(unittest.TestCase):
@@ -279,10 +283,10 @@ class TestSingleProcessValidation(unittest.TestCase):
     def test_validate_optional_tagfile_in_directory(self):
         bag = bagit.make_bag(self.tmpdir)
         tagdir = tempfile.mkdtemp(dir=self.tmpdir)
-        
+
         if not os.path.exists(j(tagdir, "tagfolder")):
             os.makedirs(j(tagdir, "tagfolder"))
-        
+
         with open(j(tagdir, "tagfolder", "tagfile"), "w") as tagfile:
             tagfile.write("test")
         relpath = j(tagdir, "tagfolder", "tagfile").replace(self.tmpdir + os.sep, "")

--- a/test.py
+++ b/test.py
@@ -1,4 +1,7 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import codecs
 import datetime
@@ -569,9 +572,9 @@ Tag-File-Character-Encoding: UTF-8
         self.assertEqual(bag.info["test"], "foobar")
 
     def test_unicode_in_tags(self):
-        bag = bagit.make_bag(self.tmpdir, {"test": '♡'})
+        bag = bagit.make_bag(self.tmpdir, {"test": u'♡'})
         bag = bagit.Bag(self.tmpdir)
-        self.assertEqual(bag.info['test'], '♡')
+        self.assertEqual(bag.info['test'], u'♡')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,5 @@ envlist = py26,py27,py33,py34,py35
 
 [testenv]
 commands = python setup.py test
+deps =
+    py26: unittest2


### PR DESCRIPTION
- Declare de facto UTF-8 source encoding
- Opt-in for Python 3 behaviors on Python 2
- Use `codecs.open()` to decode text files into `unicode` instances and open everything else in binary mode
- Handle things which are supposed to tolerate Unicode byte-order marks by using the `utf-8-sig` encoding to read them
