### PR TITLE
⚠️ Apply Unicode NFD normalization to filenames [WIP]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.tox
+.git
+__pycache__
+dist
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ python:
  - "3.4"
  - "3.5"
 script: python setup.py test
+
+install:
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.5
+RUN mkdir /bagit
+WORKDIR /bagit
+COPY *.py /bagit/
+COPY test-data /bagit/test-data/
+CMD [ "python", "setup.py", "test" ]

--- a/bagit.py
+++ b/bagit.py
@@ -206,7 +206,9 @@ class Bag(object):
         else:
             raise BagError("Unsupported bag version: %s" % self.version)
 
-        if not self.encoding.lower() == "utf-8":
+        try:
+            codecs.lookup(self.encoding)
+        except codecs.LookupError:
             raise BagValidationError("Unsupported encoding: %s" % self.encoding)
 
         info_file_path = os.path.join(self.path, self.tag_file_name)

--- a/bagit.py
+++ b/bagit.py
@@ -576,8 +576,8 @@ class BagValidationError(BagError):
 
     def __str__(self):
         if len(self.details) > 0:
-            details = u" ; ".join([force_unicode(e) for e in self.details])
-            return u"%s: %s" % (self.message, details)
+            details = " ; ".join([force_unicode(e) for e in self.details])
+            return "%s: %s" % (self.message, details)
         return self.message
 
 
@@ -654,9 +654,9 @@ def _calculate_file_hashes(full_path, f_hashers):
                 for i in f_hashers.values():
                     i.update(block)
     except IOError as e:
-        raise BagValidationError(u"could not read %s: %s" % (full_path, force_unicode(e)))
+        raise BagValidationError("could not read %s: %s" % (full_path, force_unicode(e)))
     except OSError as e:
-        raise BagValidationError(u"could not read %s: %s" % (full_path, force_unicode(e)))
+        raise BagValidationError("could not read %s: %s" % (full_path, force_unicode(e)))
 
     return dict(
         (alg, h.hexdigest()) for alg, h in f_hashers.items()

--- a/bagit.py
+++ b/bagit.py
@@ -211,7 +211,7 @@ class Bag(object):
 
         info_file_path = os.path.join(self.path, self.tag_file_name)
         if os.path.exists(info_file_path):
-            self.info = _load_tag_file(info_file_path)
+            self.info = _load_tag_file(info_file_path, encoding=self.encoding)
 
         self._load_manifests()
 
@@ -393,7 +393,7 @@ class Bag(object):
             alg = os.path.basename(manifest_file).replace(search, "").replace(".txt", "")
             self.algs.append(alg)
 
-            with open_text_file(manifest_file, 'r', encoding='utf-8-sig') as manifest_file:
+            with open_text_file(manifest_file, 'r', encoding=self.encoding) as manifest_file:
                 for line in manifest_file:
                     line = line.strip()
 
@@ -663,8 +663,8 @@ def _calculate_file_hashes(full_path, f_hashers):
     )
 
 
-def _load_tag_file(tag_file_name):
-    with open_text_file(tag_file_name, 'r', encoding='utf-8-sig') as tag_file:
+def _load_tag_file(tag_file_name, encoding='utf-8-sig'):
+    with open_text_file(tag_file_name, 'r', encoding=encoding) as tag_file:
         # Store duplicate tags as list of vals
         # in order of parsing under the same key.
         tags = {}

--- a/bagit.py
+++ b/bagit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# encoding: utf-8
 """
 BagIt is a directory, filename convention for bundling an arbitrary set of
 files with a manifest, checksums, and additional metadata. More about BagIt
@@ -31,6 +31,9 @@ For more help see:
     % bagit.py --help
 """
 
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
 import argparse
 import codecs
 import hashlib
@@ -42,6 +45,7 @@ import signal
 import sys
 import tempfile
 from datetime import date
+from functools import partial
 from os import listdir
 from os.path import abspath, isdir, isfile, join
 
@@ -68,9 +72,9 @@ STANDARD_BAG_INFO_HEADERS = [
 
 CHECKSUM_ALGOS = ['md5', 'sha1', 'sha256', 'sha512']
 
-BOM = codecs.BOM_UTF8
-if sys.version_info[0] >= 3:
-    BOM = BOM.decode('utf-8')
+#: Convenience function used everywhere we want to open
+#: a file to read text rather than undecoded bytes.
+open_text_file = partial(codecs.open, encoding='utf-8')
 
 
 def make_bag(bag_dir, bag_info=None, processes=1, checksum=None):
@@ -130,7 +134,7 @@ def make_bag(bag_dir, bag_info=None, processes=1, checksum=None):
 
             LOGGER.info("writing bagit.txt")
             txt = """BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n"""
-            with open("bagit.txt", "w") as bagit_file:
+            with open_text_file('bagit.txt', 'w') as bagit_file:
                 bagit_file.write(txt)
 
             LOGGER.info("writing bag-info.txt")
@@ -389,7 +393,7 @@ class Bag(object):
             alg = os.path.basename(manifest_file).replace(search, "").replace(".txt", "")
             self.algs.append(alg)
 
-            with open(manifest_file, 'r') as manifest_file:
+            with open_text_file(manifest_file, 'r', encoding='utf-8-sig') as manifest_file:
                 for line in manifest_file:
                     line = line.strip()
 
@@ -547,9 +551,12 @@ class Bag(object):
         Verify that bagit.txt conforms to specification
         """
         bagit_file_path = os.path.join(self.path, "bagit.txt")
-        with open(bagit_file_path, 'r') as bagit_file:
-            first_line = bagit_file.readline()
-            if first_line.startswith(BOM):
+
+        # Note that we are intentionally opening this file in binary mode so we can confirm
+        # that it does not start with the UTF-8 byte-order-mark
+        with open(bagit_file_path, 'rb') as bagit_file:
+            first_line = bagit_file.read(4)
+            if first_line.startswith(codecs.BOM_UTF8):
                 raise BagValidationError("bagit.txt must not contain a byte-order mark")
 
 
@@ -657,7 +664,7 @@ def _calculate_file_hashes(full_path, f_hashers):
 
 
 def _load_tag_file(tag_file_name):
-    with open(tag_file_name, 'r') as tag_file:
+    with open_text_file(tag_file_name, 'r', encoding='utf-8-sig') as tag_file:
         # Store duplicate tags as list of vals
         # in order of parsing under the same key.
         tags = {}
@@ -670,6 +677,7 @@ def _load_tag_file(tag_file_name):
                 tags[name] = [tags[name], value]
             else:
                 tags[name].append(value)
+
         return tags
 
 
@@ -688,10 +696,6 @@ def _parse_tags(tag_file):
     # Line folding is handled by yielding values only after we encounter
     # the start of a new tag, or if we pass the EOF.
     for num, line in enumerate(tag_file):
-        # If byte-order mark ignore it for now.
-        if num == 0:
-            if line.startswith(BOM):
-                line = line.lstrip(BOM)
         # Skip over any empty or blank lines.
         if len(line) == 0 or line.isspace():
             continue
@@ -717,8 +721,7 @@ def _parse_tags(tag_file):
 
 def _make_tag_file(bag_info_path, bag_info):
     headers = sorted(bag_info.keys())
-
-    with open(bag_info_path, 'w') as f:
+    with open_text_file(bag_info_path, 'w') as f:
         for h in headers:
             if isinstance(bag_info[h], list):
                 for val in bag_info[h]:
@@ -752,7 +755,7 @@ def _make_manifest(manifest_file, data_dir, processes, algorithm='md5'):
     else:
         checksums = [manifest_line(i) for i in _walk(data_dir)]
 
-    with open(manifest_file, 'w') as manifest:
+    with open_text_file(manifest_file, 'w') as manifest:
         num_files = 0
         total_bytes = 0
 
@@ -780,7 +783,7 @@ def _make_tagmanifest_file(alg, bag_dir):
                 m.update(block)
             checksums.append((m.hexdigest(), f))
 
-    with open(join(bag_dir, tagmanifest_file), 'w') as tagmanifest:
+    with open_text_file(join(bag_dir, tagmanifest_file), 'w') as tagmanifest:
         for digest, filename in checksums:
             tagmanifest.write('%s %s\n' % (digest, filename))
 

--- a/bagit.py
+++ b/bagit.py
@@ -487,11 +487,11 @@ class Bag(object):
         only_in_manifests, only_on_fs = self.compare_manifests_with_fs()
         for path in only_in_manifests:
             e = FileMissing(path)
-            LOGGER.warning(str(e))
+            LOGGER.warning(force_unicode(e))
             errors.append(e)
         for path in only_on_fs:
             e = UnexpectedFile(path)
-            LOGGER.warning(str(e))
+            LOGGER.warning(force_unicode(e))
             errors.append(e)
 
         # To avoid the overhead of reading the file more than once or loading
@@ -540,7 +540,7 @@ class Bag(object):
                 stored_hash = hashes[alg]
                 if stored_hash.lower() != computed_hash:
                     e = ChecksumMismatch(rel_path, alg, stored_hash.lower(), computed_hash)
-                    LOGGER.warning(str(e))
+                    LOGGER.warning(force_unicode(e))
                     errors.append(e)
 
         if errors:
@@ -576,8 +576,8 @@ class BagValidationError(BagError):
 
     def __str__(self):
         if len(self.details) > 0:
-            details = " ; ".join([str(e) for e in self.details])
-            return "%s: %s" % (self.message, details)
+            details = u" ; ".join([force_unicode(e) for e in self.details])
+            return u"%s: %s" % (self.message, details)
         return self.message
 
 
@@ -630,7 +630,7 @@ def _calc_hashes(args):
         f_hashes = _calculate_file_hashes(full_path, f_hashers)
     except BagValidationError as e:
         f_hashes = dict(
-            (alg, str(e)) for alg in f_hashers.keys()
+            (alg, force_unicode(e)) for alg in f_hashers.keys()
         )
 
     return rel_path, f_hashes, hashes
@@ -654,9 +654,9 @@ def _calculate_file_hashes(full_path, f_hashers):
                 for i in f_hashers.values():
                     i.update(block)
     except IOError as e:
-        raise BagValidationError("could not read %s: %s" % (full_path, str(e)))
+        raise BagValidationError(u"could not read %s: %s" % (full_path, force_unicode(e)))
     except OSError as e:
-        raise BagValidationError("could not read %s: %s" % (full_path, str(e)))
+        raise BagValidationError(u"could not read %s: %s" % (full_path, force_unicode(e)))
 
     return dict(
         (alg, h.hexdigest()) for alg, h in f_hashers.items()
@@ -884,6 +884,19 @@ def _decode_filename(s):
     s = re.sub(r"%0A", "\n", s, re.IGNORECASE)
     return s
 
+
+def force_unicode_py2(s):
+    """Reliably return a Unicode string given a possible unicode or byte string"""
+    if isinstance(s, str):
+        s = s.decode('utf-8')
+    else:
+        return unicode(s)
+
+
+if sys.version_info > (3, 0):
+    force_unicode = str
+else:
+    force_unicode = force_unicode_py2
 
 # following code is used for command line program
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-from sys import exit, version
+from sys import exit, version_info
 
 from setuptools import setup
 
-if version < '2.6.0':
-    print("python 2.6 or higher is required")
+if version_info < (2, 6):
+    print("Python 2.6 or higher is required")
     exit(1)
 
 description = \
@@ -24,6 +24,10 @@ try:
 except:
     requirements.append("hashlib")
 
+if version_info < (2, 7):
+    test_requires = ['unittest2']
+else:
+    test_requires = []
 
 setup(
     name = 'bagit',
@@ -37,6 +41,7 @@ setup(
     platforms = ['POSIX'],
     test_suite = 'test',
     install_requires = requirements,
+    test_requires = test_requires,
     classifiers = [
         'License :: Public Domain',
         'Intended Audience :: Developers',

--- a/test.py
+++ b/test.py
@@ -538,9 +538,9 @@ Tag-File-Character-Encoding: UTF-8
         self.assertEqual(bag.info["test"], "foobar")
 
     def test_unicode_in_tags(self):
-        bag = bagit.make_bag(self.tmpdir, {"test": u'♡'})
+        bag = bagit.make_bag(self.tmpdir, {"test": '♡'})
         bag = bagit.Bag(self.tmpdir)
-        self.assertEqual(bag.info['test'], u'♡')
+        self.assertEqual(bag.info['test'], '♡')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -15,6 +15,9 @@ import tempfile
 import unittest
 from os.path import join as j
 
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+
 import bagit
 
 # don't let < ERROR clutter up test output

--- a/test.py
+++ b/test.py
@@ -308,9 +308,13 @@ class TestSingleProcessValidation(unittest.TestCase):
         decomposed = u'\N{LATIN SMALL LETTER I}\N{COMBINING ACUTE ACCENT}'
         composed = u'\N{LATIN SMALL LETTER I WITH ACUTE}'
 
-        open(j(self.tmpdir, decomposed), 'w').write('')
+        with open(j(self.tmpdir, decomposed), 'w') as f:
+            f.write('')
+
         bag = bagit.make_bag(self.tmpdir, checksum=["md5"])
-        manifest_txt = codecs.open(j(self.tmpdir, 'manifest-md5.txt'), 'r', 'utf8').read()
+
+        manifest_txt = slurp_text_file(j(self.tmpdir, 'manifest-md5.txt'))
+
         os.rename(j(self.tmpdir, 'data', decomposed),
                   j(self.tmpdir, 'data', composed))
         # FIXME: use assertIn once we finally drop Python 2.6

--- a/test.py
+++ b/test.py
@@ -1,4 +1,7 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import codecs
 import datetime
@@ -535,9 +538,9 @@ Tag-File-Character-Encoding: UTF-8
         self.assertEqual(bag.info["test"], "foobar")
 
     def test_unicode_in_tags(self):
-        bag = bagit.make_bag(self.tmpdir, {"test": '♡'})
+        bag = bagit.make_bag(self.tmpdir, {"test": u'♡'})
         bag = bagit.Bag(self.tmpdir)
-        self.assertEqual(bag.info['test'], '♡')
+        self.assertEqual(bag.info['test'], u'♡')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -285,6 +285,19 @@ class TestSingleProcessValidation(unittest.TestCase):
         os.chmod(j(self.tmpdir, "data/loc/2478433644_2839c5e8b8_o_d.jpg"), 0)
         self.assertRaises(bagit.BagValidationError, self.validate, bag, fast=False)
 
+    def test_unicode_normalization(self):
+        decomposed = u'\N{LATIN SMALL LETTER I}\N{COMBINING ACUTE ACCENT}'
+        composed = u'\N{LATIN SMALL LETTER I WITH ACUTE}'
+
+        open(j(self.tmpdir, decomposed), 'w').write('')
+        bag = bagit.make_bag(self.tmpdir, checksum=["md5"])
+        manifest_txt = codecs.open(j(self.tmpdir, 'manifest-md5.txt'), 'r', 'utf8').read()
+        os.rename(j(self.tmpdir, 'data', decomposed),
+                  j(self.tmpdir, 'data', composed))
+        # FIXME: use assertIn once we finally drop Python 2.6
+        self.assertTrue(u'd41d8cd98f00b204e9800998ecf8427e  data/%s' % decomposed in manifest_txt)
+        self.assertTrue(self.validate(bag))
+
 
 class TestMultiprocessValidation(TestSingleProcessValidation):
 

--- a/test.py
+++ b/test.py
@@ -21,9 +21,13 @@ if sys.version_info < (2, 7):
 
 import bagit
 
-# don't let < ERROR clutter up test output
-logging.basicConfig(filename="test.log", level=logging.DEBUG)
+logging.basicConfig(filename='test.log', level=logging.DEBUG)
+stdout = logging.StreamHandler(stream=sys.stdout)
+stdout.setLevel(logging.WARNING)
+logging.getLogger().addHandler(stdout)
 
+# But we do want any exceptions raised in the logging path to be raised:
+logging.raiseExceptions = True
 
 def slurp_text_file(filename):
     with bagit.open_text_file(filename) as f:

--- a/test.py
+++ b/test.py
@@ -24,6 +24,26 @@ import bagit
 logging.basicConfig(filename="test.log", level=logging.DEBUG)
 
 
+def slurp_text_file(filename):
+    with bagit.open_text_file(filename) as f:
+        return f.read()
+
+
+def create_unicode_test_payload_files(tmpdir):
+    # To avoid conflicts caused by version-control systems or filesystem differences we'll create this one
+    # test file directly using escaped strings in both NFC and NFD forms:
+
+    utf8_test_filenames = [
+        b'U\xcc\x88n\xcc\x83i\xcc\x81c\xcc\xa7\xc3\xb8\xe1\xb4\x86\xcc\x81e\xcc\x84-NFD.txt',
+        b'\xc3\x9c\xc3\xb1\xc3\xad\xc3\xa7\xc3\xb8\xe1\xb4\x86\xcc\x81\xc4\x93-NFC.txt',
+    ]
+
+    for utf8_test_filename in utf8_test_filenames:
+        with open(j(tmpdir, 'loc', utf8_test_filename.decode('utf-8')), 'wb') as test_file:
+            test_file.write('In\u0303te\u0308rna\u0302tio\u0302na\u0300liz\u00e6ti\u00f8n is important! '.encode('utf-8'))
+            test_file.write(b'\xf0\x9f\x8c\x8e\xf0\x9f\x8c\x8f\xf0\x9f\x8c\x8d')
+
+
 class TestSingleProcessValidation(unittest.TestCase):
 
     def setUp(self):
@@ -31,6 +51,8 @@ class TestSingleProcessValidation(unittest.TestCase):
         if os.path.isdir(self.tmpdir):
             shutil.rmtree(self.tmpdir)
         shutil.copytree('test-data', self.tmpdir)
+
+        create_unicode_test_payload_files(self.tmpdir)
 
     def tearDown(self):
         if os.path.isdir(self.tmpdir):
@@ -67,8 +89,7 @@ class TestSingleProcessValidation(unittest.TestCase):
     def test_validate_flipped_bit(self):
         bag = bagit.make_bag(self.tmpdir)
         readme = j(self.tmpdir, "data", "README")
-        with open(readme) as r:
-            txt = r.read()
+        txt = slurp_text_file(readme)
         txt = 'A' + txt[1:]
         with open(readme, "w") as r:
             r.write(txt)
@@ -101,8 +122,7 @@ class TestSingleProcessValidation(unittest.TestCase):
     def test_validation_error_details(self):
         bag = bagit.make_bag(self.tmpdir)
         readme = j(self.tmpdir, "data", "README")
-        with open(readme) as r:
-            txt = r.read()
+        txt = slurp_text_file(readme)
         txt = 'A' + txt[1:]
         with open(readme, "w") as r:
             r.write(txt)
@@ -218,18 +238,18 @@ class TestSingleProcessValidation(unittest.TestCase):
             if key.startswith('data' + os.sep):
                 hashstr = bag.entries[key]
         hashstr = next(iter(hashstr.values()))
-        with open(j(self.tmpdir, "manifest-md5.txt"), "r") as m:
-            manifest = m.read()
+        manifest = slurp_text_file(j(self.tmpdir, "manifest-md5.txt"))
+
         manifest = manifest.replace(hashstr, hashstr.upper())
-        with open(j(self.tmpdir, "manifest-md5.txt"), "w") as m:
-            m.write(manifest)
+
+        with open(j(self.tmpdir, "manifest-md5.txt"), "wb") as m:
+            m.write(manifest.encode('utf-8'))
 
         # Since manifest-md5.txt file is updated, re-calculate its
         # md5 checksum and update it in the tagmanifest-md5.txt file
         hasher = hashlib.new('md5')
-        with open(j(self.tmpdir, "manifest-md5.txt"), "r") as manifest:
-            contents = manifest.read().encode('utf-8')
-            hasher.update(contents)
+        contents = slurp_text_file(j(self.tmpdir, "manifest-md5.txt")).encode('utf-8')
+        hasher.update(contents)
         with open(j(self.tmpdir, "tagmanifest-md5.txt"), "r") as tagmanifest:
             tagman_contents = tagmanifest.read()
             tagman_contents = tagman_contents.replace(
@@ -261,8 +281,7 @@ class TestSingleProcessValidation(unittest.TestCase):
         self.assertRaises(bagit.BagValidationError, self.validate, bag)
 
         hasher = hashlib.new("md5")
-        with open(j(tagdir, "tagfile"), "r") as tf:
-            contents = tf.read().encode('utf-8')
+        contents = slurp_text_file(j(tagdir, "tagfile")).encode('utf-8')
         hasher.update(contents)
         with open(j(self.tmpdir, "tagmanifest-md5.txt"), "w") as tagman:
             tagman.write(hasher.hexdigest() + " " + relpath + "\n")
@@ -278,7 +297,7 @@ class TestSingleProcessValidation(unittest.TestCase):
         info = {'Bagging-Date': '1970-01-01', 'Contact-Email': 'ehs@pobox.com'}
         bag = bagit.make_bag(self.tmpdir, checksum=['sha1'], bag_info=info)
         self.assertTrue(os.path.isfile(j(self.tmpdir, 'tagmanifest-sha1.txt')))
-        self.assertEqual(bag.entries['bag-info.txt']['sha1'], 'd7f086508df433e5d7464b5a3835d5501df14404')
+        self.assertEqual(bag.entries['bag-info.txt']['sha1'], 'ef616051f925ab79ab1cbfda4d926c3bb6e8a3de')
 
     def test_validate_unreadable_file(self):
         bag = bagit.make_bag(self.tmpdir, checksum=["md5"])
@@ -300,18 +319,18 @@ class TestSingleProcessValidation(unittest.TestCase):
 
 
 class TestMultiprocessValidation(TestSingleProcessValidation):
-
     def validate(self, bag, *args, **kwargs):
         return super(TestMultiprocessValidation, self).validate(bag, *args, processes=2, **kwargs)
 
 
 class TestBag(unittest.TestCase):
-
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         if os.path.isdir(self.tmpdir):
             shutil.rmtree(self.tmpdir)
         shutil.copytree('test-data', self.tmpdir)
+
+        create_unicode_test_payload_files(self.tmpdir)
 
     def tearDown(self):
         if os.path.isdir(self.tmpdir):
@@ -326,71 +345,84 @@ class TestBag(unittest.TestCase):
 
         # check bagit.txt
         self.assertTrue(os.path.isfile(j(self.tmpdir, 'bagit.txt')))
-        with open(j(self.tmpdir, 'bagit.txt')) as b:
-            bagit_txt = b.read()
+        bagit_txt = slurp_text_file(j(self.tmpdir, 'bagit.txt'))
         self.assertTrue('BagIt-Version: 0.97' in bagit_txt)
         self.assertTrue('Tag-File-Character-Encoding: UTF-8' in bagit_txt)
 
         # check manifest
         self.assertTrue(os.path.isfile(j(self.tmpdir, 'manifest-md5.txt')))
-        with open(j(self.tmpdir, 'manifest-md5.txt')) as m:
-            manifest_txt = m.read()
-        self.assertTrue('8e2af7a0143c7b8f4de0b3fc90f27354  data/README' in manifest_txt)
-        self.assertTrue('9a2b89e9940fea6ac3a0cc71b0a933a0  data/loc/2478433644_2839c5e8b8_o_d.jpg' in manifest_txt)
-        self.assertTrue('6172e980c2767c12135e3b9d246af5a3  data/loc/3314493806_6f1db86d66_o_d.jpg' in manifest_txt)
-        self.assertTrue('38a84cd1c41de793a0bccff6f3ec8ad0  data/si/2584174182_ffd5c24905_b_d.jpg' in manifest_txt)
-        self.assertTrue('5580eaa31ad1549739de12df819e9af8  data/si/4011399822_65987a4806_b_d.jpg' in manifest_txt)
+
+        manifest_txt = slurp_text_file(j(self.tmpdir, 'manifest-md5.txt'))
+
+        self.assertIn('8e2af7a0143c7b8f4de0b3fc90f27354  data/README', manifest_txt)
+        self.assertIn('9a2b89e9940fea6ac3a0cc71b0a933a0  data/loc/2478433644_2839c5e8b8_o_d.jpg', manifest_txt)
+        self.assertIn('6172e980c2767c12135e3b9d246af5a3  data/loc/3314493806_6f1db86d66_o_d.jpg', manifest_txt)
+        self.assertIn('38a84cd1c41de793a0bccff6f3ec8ad0  data/si/2584174182_ffd5c24905_b_d.jpg', manifest_txt)
+        self.assertIn('5580eaa31ad1549739de12df819e9af8  data/si/4011399822_65987a4806_b_d.jpg', manifest_txt)
 
         # check bag-info.txt
         self.assertTrue(os.path.isfile(j(self.tmpdir, 'bag-info.txt')))
-        with open(j(self.tmpdir, 'bag-info.txt')) as bi:
-            bag_info_txt = bi.read()
-        self.assertTrue('Contact-Email: ehs@pobox.com' in bag_info_txt)
-        self.assertTrue('Bagging-Date: 1970-01-01' in bag_info_txt)
-        self.assertTrue('Payload-Oxum: 991765.5' in bag_info_txt)
-        self.assertTrue('Bag-Software-Agent: bagit.py <http://github.com/libraryofcongress/bagit-python>' in bag_info_txt)
+        bag_info_txt = slurp_text_file(j(self.tmpdir, 'bag-info.txt'))
+
+        self.assertIn('Contact-Email: ehs@pobox.com', bag_info_txt)
+        self.assertIn('Bagging-Date: 1970-01-01', bag_info_txt)
+        self.assertIn('Payload-Oxum: 991883.7', bag_info_txt)
+        self.assertIn('Bag-Software-Agent: bagit.py <http://github.com/libraryofcongress/bagit-python>',
+                      bag_info_txt)
 
         # check tagmanifest-md5.txt
         self.assertTrue(os.path.isfile(j(self.tmpdir, 'tagmanifest-md5.txt')))
-        with open(j(self.tmpdir, 'tagmanifest-md5.txt')) as tm:
-            tagmanifest_txt = tm.read()
-        self.assertTrue('9e5ad981e0d29adc278f6a294b8c2aca bagit.txt' in tagmanifest_txt)
-        self.assertTrue('a0ce6631a2a6d1a88e6d38453ccc72a5 manifest-md5.txt' in tagmanifest_txt)
-        self.assertTrue('6a5090e27cb29d5dda8a0142fbbdf37e bag-info.txt' in tagmanifest_txt)
+        tagmanifest_txt = slurp_text_file(j(self.tmpdir, 'tagmanifest-md5.txt'))
+
+        self.assertIn('9e5ad981e0d29adc278f6a294b8c2aca bagit.txt', tagmanifest_txt)
+        self.assertIn('b82a068ea478adc9b110e66f70b114d9 manifest-md5.txt', tagmanifest_txt)
+        self.assertIn('5dfd015b9bcbe0bba0fe3f2730caf014 bag-info.txt', tagmanifest_txt)
 
     def test_make_bag_sha1_manifest(self):
         bagit.make_bag(self.tmpdir, checksum=['sha1'])
         # check manifest
         self.assertTrue(os.path.isfile(j(self.tmpdir, 'manifest-sha1.txt')))
-        with open(j(self.tmpdir, 'manifest-sha1.txt')) as m:
-            manifest_txt = m.read()
-        self.assertTrue('ace19416e605cfb12ab11df4898ca7fd9979ee43  data/README' in manifest_txt)
-        self.assertTrue('4c0a3da57374e8db379145f18601b159f3cad44b  data/loc/2478433644_2839c5e8b8_o_d.jpg' in manifest_txt)
-        self.assertTrue('62095aeddae2f3207cb77c85937e13c51641ef71  data/loc/3314493806_6f1db86d66_o_d.jpg' in manifest_txt)
-        self.assertTrue('e592194b3733e25166a631e1ec55bac08066cbc1  data/si/2584174182_ffd5c24905_b_d.jpg' in manifest_txt)
-        self.assertTrue('db49ef009f85a5d0701829f38d29f8cf9c5df2ea  data/si/4011399822_65987a4806_b_d.jpg' in manifest_txt)
+        manifest_txt = slurp_text_file(j(self.tmpdir, 'manifest-sha1.txt'))
+
+        self.assertIn('ace19416e605cfb12ab11df4898ca7fd9979ee43  data/README',
+                      manifest_txt)
+        self.assertIn('4c0a3da57374e8db379145f18601b159f3cad44b  data/loc/2478433644_2839c5e8b8_o_d.jpg',
+                      manifest_txt)
+        self.assertIn('62095aeddae2f3207cb77c85937e13c51641ef71  data/loc/3314493806_6f1db86d66_o_d.jpg',
+                      manifest_txt)
+        self.assertIn('e592194b3733e25166a631e1ec55bac08066cbc1  data/si/2584174182_ffd5c24905_b_d.jpg',
+                      manifest_txt)
+        self.assertIn('db49ef009f85a5d0701829f38d29f8cf9c5df2ea  data/si/4011399822_65987a4806_b_d.jpg',
+                      manifest_txt)
 
     def test_make_bag_sha256_manifest(self):
         bagit.make_bag(self.tmpdir, checksum=['sha256'])
         # check manifest
         self.assertTrue(os.path.isfile(j(self.tmpdir, 'manifest-sha256.txt')))
-        with open(j(self.tmpdir, 'manifest-sha256.txt')) as m:
-            manifest_txt = m.read()
-        self.assertTrue('b6df8058fa818acfd91759edffa27e473f2308d5a6fca1e07a79189b95879953  data/loc/2478433644_2839c5e8b8_o_d.jpg' in manifest_txt)
-        self.assertTrue('1af90c21e72bb0575ae63877b3c69cfb88284f6e8c7820f2c48dc40a08569da5  data/loc/3314493806_6f1db86d66_o_d.jpg' in manifest_txt)
-        self.assertTrue('f065a4ae2bc5d47c6d046c3cba5c8cdfd66b07c96ff3604164e2c31328e41c1a  data/si/2584174182_ffd5c24905_b_d.jpg' in manifest_txt)
-        self.assertTrue('45d257c93e59ec35187c6a34c8e62e72c3e9cfbb548984d6f6e8deb84bac41f4  data/si/4011399822_65987a4806_b_d.jpg' in manifest_txt)
+        manifest_txt = slurp_text_file(j(self.tmpdir, 'manifest-sha256.txt'))
+
+        self.assertIn('b6df8058fa818acfd91759edffa27e473f2308d5a6fca1e07a79189b95879953  data/loc/2478433644_2839c5e8b8_o_d.jpg',
+                      manifest_txt)
+        self.assertIn('1af90c21e72bb0575ae63877b3c69cfb88284f6e8c7820f2c48dc40a08569da5  data/loc/3314493806_6f1db86d66_o_d.jpg',
+                      manifest_txt)
+        self.assertIn('f065a4ae2bc5d47c6d046c3cba5c8cdfd66b07c96ff3604164e2c31328e41c1a  data/si/2584174182_ffd5c24905_b_d.jpg',
+                      manifest_txt)
+        self.assertIn('45d257c93e59ec35187c6a34c8e62e72c3e9cfbb548984d6f6e8deb84bac41f4  data/si/4011399822_65987a4806_b_d.jpg',
+                      manifest_txt)
 
     def test_make_bag_sha512_manifest(self):
         bagit.make_bag(self.tmpdir, checksum=['sha512'])
         # check manifest
         self.assertTrue(os.path.isfile(j(self.tmpdir, 'manifest-sha512.txt')))
-        with open(j(self.tmpdir, 'manifest-sha512.txt')) as m:
-            manifest_txt = m.read()
-        self.assertTrue('51fb9236a23795886cf42d539d580739245dc08f72c3748b60ed8803c9cb0e2accdb91b75dbe7d94a0a461827929d720ef45fe80b825941862fcde4c546a376d  data/loc/2478433644_2839c5e8b8_o_d.jpg' in manifest_txt)
-        self.assertTrue('627c15be7f9aabc395c8b2e4c3ff0b50fd84b3c217ca38044cde50fd4749621e43e63828201fa66a97975e316033e4748fb7a4a500183b571ecf17715ec3aea3  data/loc/3314493806_6f1db86d66_o_d.jpg' in manifest_txt)
-        self.assertTrue('4cb4dafe39b2539536a9cb31d5addf335734cb91e2d2786d212a9b574e094d7619a84ad53f82bd9421478a7994cf9d3f44fea271d542af09d26ce764edbada46  data/si/2584174182_ffd5c24905_b_d.jpg' in manifest_txt)
-        self.assertTrue('af1c03483cd1999098cce5f9e7689eea1f81899587508f59ba3c582d376f8bad34e75fed55fd1b1c26bd0c7a06671b85e90af99abac8753ad3d76d8d6bb31ebd  data/si/4011399822_65987a4806_b_d.jpg' in manifest_txt)
+        manifest_txt = slurp_text_file(j(self.tmpdir, 'manifest-sha512.txt'))
+        self.assertIn('51fb9236a23795886cf42d539d580739245dc08f72c3748b60ed8803c9cb0e2accdb91b75dbe7d94a0a461827929d720ef45fe80b825941862fcde4c546a376d  data/loc/2478433644_2839c5e8b8_o_d.jpg',
+                      manifest_txt)
+        self.assertIn('627c15be7f9aabc395c8b2e4c3ff0b50fd84b3c217ca38044cde50fd4749621e43e63828201fa66a97975e316033e4748fb7a4a500183b571ecf17715ec3aea3  data/loc/3314493806_6f1db86d66_o_d.jpg',
+                      manifest_txt)
+        self.assertIn('4cb4dafe39b2539536a9cb31d5addf335734cb91e2d2786d212a9b574e094d7619a84ad53f82bd9421478a7994cf9d3f44fea271d542af09d26ce764edbada46  data/si/2584174182_ffd5c24905_b_d.jpg',
+                      manifest_txt)
+        self.assertIn('af1c03483cd1999098cce5f9e7689eea1f81899587508f59ba3c582d376f8bad34e75fed55fd1b1c26bd0c7a06671b85e90af99abac8753ad3d76d8d6bb31ebd  data/si/4011399822_65987a4806_b_d.jpg',
+                      manifest_txt)
 
     def test_make_bag_unknown_algorithm(self):
         self.assertRaises(RuntimeError, bagit.make_bag, self.tmpdir, checksum=['not-really-a-name'])
@@ -406,14 +438,16 @@ class TestBag(unittest.TestCase):
         info = {'Contact-Email': 'ehs@pobox.com'}
         bag = bagit.make_bag(self.tmpdir, bag_info=info)
         self.assertTrue(isinstance(bag, bagit.Bag))
-        self.assertEqual(set(bag.payload_files()), set([
-            'data/README',
-            'data/si/2584174182_ffd5c24905_b_d.jpg',
-            'data/si/4011399822_65987a4806_b_d.jpg',
-            'data/loc/2478433644_2839c5e8b8_o_d.jpg',
-            'data/loc/3314493806_6f1db86d66_o_d.jpg']))
-        self.assertEqual(list(bag.manifest_files()), ['%s/manifest-md5.txt' %
-            self.tmpdir])
+        self.assertSetEqual(set(bag.payload_files()),
+                            set(('data/README',
+                                 'data/si/2584174182_ffd5c24905_b_d.jpg',
+                                 'data/si/4011399822_65987a4806_b_d.jpg',
+                                 'data/loc/2478433644_2839c5e8b8_o_d.jpg',
+                                 'data/loc/3314493806_6f1db86d66_o_d.jpg',
+                                 'data/loc/Üñíçøᴆ́ē-NFC.txt',
+                                 'data/loc/Üñíçøᴆ́ē-NFD.txt')))
+        self.assertEqual(list(bag.manifest_files()),
+                         ['%s/manifest-md5.txt' % self.tmpdir])
 
     def test_has_oxum(self):
         bag = bagit.make_bag(self.tmpdir)
@@ -423,7 +457,7 @@ class TestBag(unittest.TestCase):
         bag = bagit.make_bag(self.tmpdir)
         bag = bagit.Bag(self.tmpdir)
         self.assertEqual(type(bag), bagit.Bag)
-        self.assertEqual(len(list(bag.payload_files())), 5)
+        self.assertEqual(len(list(bag.payload_files())), 7)
 
     def test_is_valid(self):
         bag = bagit.make_bag(self.tmpdir)
@@ -456,9 +490,8 @@ Tag-File-Character-Encoding: UTF-8
 
     def test_default_bagging_date(self):
         info = {'Contact-Email': 'ehs@pobox.com'}
-        bagit.make_bag(self.tmpdir, bag_info=info)
-        with open(j(self.tmpdir, 'bag-info.txt')) as bi:
-            bag_info_txt = bi.read()
+        bag = bagit.make_bag(self.tmpdir, bag_info=info)
+        bag_info_txt = slurp_text_file(j(self.tmpdir, 'bag-info.txt'))
         self.assertTrue('Contact-Email: ehs@pobox.com' in bag_info_txt)
         today = datetime.date.strftime(datetime.date.today(), "%Y-%m-%d")
         self.assertTrue('Bagging-Date: %s' % today in bag_info_txt)

--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,5 @@ envlist = py26,py27,py33,py34,py35
 
 [testenv]
 commands = python setup.py test
+deps =
+    py26: unittest2


### PR DESCRIPTION
This commit simply ensures that bagit.py will normal filenames to NFD when
reading or writing a manifest.

Requires the Unicode handling cleanup from #55.

Closes #51
- [ ] Unit tests for core encoding functions
- [ ] Update test case to expect different normalization forms to result in the same file (OS X)
- [ ] Update test case to expect different normalization forms to result in different files (everything else)
