### PR TITLE
be more verbose  when verifying checksums

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -626,6 +626,7 @@ def _calculate_file_hashes(full_path, f_hashers):
     Returns a dictionary of (algorithm, hexdigest) values for the provided
     filename
     """
+    LOGGER.info("Verifying checksum for file %s", full_path)
     if not os.path.exists(full_path):
         raise BagValidationError("%s does not exist" % full_path)
 


### PR DESCRIPTION
Similar to https://github.com/LibraryOfCongress/bagit-python/issues/59 , large verifications of multiple files can take a long time, so having more status updates is more meaningful and reassuring. Let me know if I put this in the wrong place/function.