### PR TITLE
Reset entries dict when reloading manifests

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -751,8 +751,7 @@ def _make_manifest(manifest_file, data_dir, processes, algorithm='md5'):
             num_files += 1
             total_bytes += byte_count
             manifest.write("%s  %s\n" % (digest, _encode_filename(filename)))
-        manifest.close()
-        return "%s.%s" % (total_bytes, num_files)
+    return "%s.%s" % (total_bytes, num_files)
 
 
 def _make_tagmanifest_file(alg, bag_dir):

--- a/bagit.py
+++ b/bagit.py
@@ -374,6 +374,7 @@ class Bag(object):
         return True
 
     def _load_manifests(self):
+        self.entries = {}
         manifests = list(self.manifest_files())
 
         if self.version == "0.97":

--- a/test.py
+++ b/test.py
@@ -483,6 +483,16 @@ Tag-File-Character-Encoding: UTF-8
         bag.save(manifests=True)
         self.assertTrue(bag.is_valid())
 
+    def test_save_manifests_deleted_files(self):
+        bag = bagit.make_bag(self.tmpdir)
+        self.assertTrue(bag.is_valid())
+        bag.save(manifests=True)
+        self.assertTrue(bag.is_valid())
+        os.remove(j(self.tmpdir, "data", "loc", "2478433644_2839c5e8b8_o_d.jpg"))
+        self.assertRaises(bagit.BagValidationError, bag.validate, bag, fast=False)
+        bag.save(manifests=True)
+        self.assertTrue(bag.is_valid())
+
     def test_save_baginfo(self):
         bag = bagit.make_bag(self.tmpdir)
 


### PR DESCRIPTION
Reset `self.entries` to empty when (re)loading manifests to catch when files have been deleted from the bag.  I ran into this problem when saving a modified bag with `manifests=True` and it raised an error that deleted files were still in the manifest.