### PR TITLE
Add an option to not to move the payload into a subdirectory on bag create

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -129,9 +129,10 @@ def make_bag(bag_dir, bag_info=None, processes=1, checksum=None,
 
             else:
 
-                if not (os.listdir('.') == ['data'] and
-                        isdir('data') and not islink('data')):
-                    raise BagError("Bag directory must have the payload subdirectory and no other entries.")
+                if not (isdir('data') and not islink('data')):
+                    raise BagError("Bag directory must have the payload subdirectory.")
+                if os.listdir('.') != ['data']:
+                    raise BagError("Bag directory must not have any entries other then the payload subdirectory.")
 
             for c in checksum:
                 LOGGER.info("writing manifest-%s.txt", c)

--- a/bagit.py
+++ b/bagit.py
@@ -925,6 +925,8 @@ def _make_parser():
                       help='Generate SHA-256 manifest when creating a bag')
     parser.add_argument('--sha512', action='append_const', dest='checksum', const='sha512',
                       help='Generate SHA-512 manifest when creating a bag')
+    parser.add_argument('--no-move-payload', action='store_false', dest='move_payload',
+                      help='Do not move the payload in a subdirectory of the bag directory, assume the payload directory to be already set up')
 
     for header in STANDARD_BAG_INFO_HEADERS:
         parser.add_argument('--%s' % header.lower(), type=str,
@@ -978,7 +980,8 @@ def main():
             try:
                 make_bag(bag_dir, bag_info=parser.bag_info,
                          processes=args.processes,
-                         checksum=args.checksum)
+                         checksum=args.checksum,
+                         move_payload=args.move_payload)
             except Exception as exc:
                 LOGGER.error("Failed to create bag in %s: %s", bag_dir, exc, exc_info=True)
                 rc = 1

--- a/test.py
+++ b/test.py
@@ -540,9 +540,7 @@ Tag-File-Character-Encoding: UTF-8
         self.assertEqual(bag.info['test'], '♡')
 
 class TestBagNoMovePayload(unittest.TestCase):
-    """Same test as test_make_bag (test.TestBag), but with the payload
-    in the right place in the data directory already from the
-    beginning and setting move_payload=False.
+    """Tests for creating a bag with move_payload=False.
     """
 
     def setUp(self):
@@ -594,6 +592,19 @@ class TestBagNoMovePayload(unittest.TestCase):
         self.assertTrue('9e5ad981e0d29adc278f6a294b8c2aca bagit.txt' in tagmanifest_txt)
         self.assertTrue('a0ce6631a2a6d1a88e6d38453ccc72a5 manifest-md5.txt' in tagmanifest_txt)
         self.assertTrue('6a5090e27cb29d5dda8a0142fbbdf37e bag-info.txt' in tagmanifest_txt)
+
+    def test_make_bag_err_no_payload(self):
+        os.rename(j(self.tmpdir, 'data'), j(self.tmpdir, 'foo'))
+        info = {'Bagging-Date': '1970-01-01', 'Contact-Email': 'ehs@pobox.com'}
+        with self.assertRaises(bagit.BagError):
+            bagit.make_bag(self.tmpdir, bag_info=info, move_payload=False)
+
+    def test_make_bag_err_spurious_files(self):
+        with open(j(self.tmpdir, 'bogus'), 'wt'):
+            pass
+        info = {'Bagging-Date': '1970-01-01', 'Contact-Email': 'ehs@pobox.com'}
+        with self.assertRaises(bagit.BagError):
+            bagit.make_bag(self.tmpdir, bag_info=info, move_payload=False)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -539,5 +539,61 @@ Tag-File-Character-Encoding: UTF-8
         bag = bagit.Bag(self.tmpdir)
         self.assertEqual(bag.info['test'], '♡')
 
+class TestBagNoMovePayload(unittest.TestCase):
+    """Same test as test_make_bag (test.TestBag), but with the payload
+    in the right place in the data directory already from the
+    beginning and setting move_payload=False.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        datadir = os.path.join(self.tmpdir, 'data')
+        shutil.copytree('test-data', datadir)
+
+    def tearDown(self):
+        if os.path.isdir(self.tmpdir):
+            shutil.rmtree(self.tmpdir)
+
+    def test_make_bag(self):
+        info = {'Bagging-Date': '1970-01-01', 'Contact-Email': 'ehs@pobox.com'}
+        bagit.make_bag(self.tmpdir, bag_info=info, move_payload=False)
+
+        # data dir should've been created
+        self.assertTrue(os.path.isdir(j(self.tmpdir, 'data')))
+
+        # check bagit.txt
+        self.assertTrue(os.path.isfile(j(self.tmpdir, 'bagit.txt')))
+        with open(j(self.tmpdir, 'bagit.txt')) as b:
+            bagit_txt = b.read()
+        self.assertTrue('BagIt-Version: 0.97' in bagit_txt)
+        self.assertTrue('Tag-File-Character-Encoding: UTF-8' in bagit_txt)
+
+        # check manifest
+        self.assertTrue(os.path.isfile(j(self.tmpdir, 'manifest-md5.txt')))
+        with open(j(self.tmpdir, 'manifest-md5.txt')) as m:
+            manifest_txt = m.read()
+        self.assertTrue('8e2af7a0143c7b8f4de0b3fc90f27354  data/README' in manifest_txt)
+        self.assertTrue('9a2b89e9940fea6ac3a0cc71b0a933a0  data/loc/2478433644_2839c5e8b8_o_d.jpg' in manifest_txt)
+        self.assertTrue('6172e980c2767c12135e3b9d246af5a3  data/loc/3314493806_6f1db86d66_o_d.jpg' in manifest_txt)
+        self.assertTrue('38a84cd1c41de793a0bccff6f3ec8ad0  data/si/2584174182_ffd5c24905_b_d.jpg' in manifest_txt)
+        self.assertTrue('5580eaa31ad1549739de12df819e9af8  data/si/4011399822_65987a4806_b_d.jpg' in manifest_txt)
+
+        # check bag-info.txt
+        self.assertTrue(os.path.isfile(j(self.tmpdir, 'bag-info.txt')))
+        with open(j(self.tmpdir, 'bag-info.txt')) as bi:
+            bag_info_txt = bi.read()
+        self.assertTrue('Contact-Email: ehs@pobox.com' in bag_info_txt)
+        self.assertTrue('Bagging-Date: 1970-01-01' in bag_info_txt)
+        self.assertTrue('Payload-Oxum: 991765.5' in bag_info_txt)
+        self.assertTrue('Bag-Software-Agent: bagit.py <http://github.com/libraryofcongress/bagit-python>' in bag_info_txt)
+
+        # check tagmanifest-md5.txt
+        self.assertTrue(os.path.isfile(j(self.tmpdir, 'tagmanifest-md5.txt')))
+        with open(j(self.tmpdir, 'tagmanifest-md5.txt')) as tm:
+            tagmanifest_txt = tm.read()
+        self.assertTrue('9e5ad981e0d29adc278f6a294b8c2aca bagit.txt' in tagmanifest_txt)
+        self.assertTrue('a0ce6631a2a6d1a88e6d38453ccc72a5 manifest-md5.txt' in tagmanifest_txt)
+        self.assertTrue('6a5090e27cb29d5dda8a0142fbbdf37e bag-info.txt' in tagmanifest_txt)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When creating a new bag, `make_bag()` takes the bag directory as argument.  It assumes the current content of this bag directory to be the payload.  It creates a new subdirectory `data` and moves all content of the bag directory into this new subdirectory.

Now, I have a use case, where I must access the payload read only when creating a new bag.  I cannot move the payload.  But I can arrange the payload to be already in the right place from the beginning.  So I need an option to tell `make_bag()`: "Do not move the payload, it's already right there where it should be."

This PR adds this option: it adds a new optional flag `move_payload` to `make_bag()`.  If this flag is `True`, the default, `make_bag()` behaves exactly as before: it creates the payload directory and moves the current content of the bag dir into this subdirectory.  If the flag is `False`, `make_bag()` assumes that the payload directory is already at its place and verifies that the bag dir does not contain anything else then this payload directory.  The PR furthermore makes the new flag accessible by a new command line option to `bagit.py`.