### PR TITLE
Add Python 3.5 to PyPI tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,6 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
 )


### PR DESCRIPTION
Travis tests it since 3e4fb362c0afa711f8c36606bfafc94839eda4a7 so we should advertise it.