### PR TITLE
Use setuptools_scm to manage version numbering

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -44,10 +44,16 @@ import tempfile
 from datetime import date
 from os import listdir
 from os.path import abspath, isdir, isfile, join
+from pkg_resources import DistributionNotFound, get_distribution
 
-LOGGER = logging.getLogger(__name__)
+MODULE_NAME = 'bagit' if __name__ == '__main__' else __name__
 
-VERSION = '1.5.4'
+LOGGER = logging.getLogger(MODULE_NAME)
+
+try:
+    VERSION = get_distribution(MODULE_NAME).version
+except DistributionNotFound:
+    VERSION = '0.0.dev0'
 
 # standard bag-info.txt metadata
 STANDARD_BAG_INFO_HEADERS = [
@@ -912,7 +918,7 @@ class BagHeaderAction(argparse.Action):
 
 
 def _make_parser():
-    parser = BagArgumentParser()
+    parser = BagArgumentParser(description='bagit-python version %s' % VERSION)
     parser.add_argument('--processes', type=int, dest='processes', default=1,
                       help='parallelize checksums generation and verification')
     parser.add_argument('--log', help='The name of the log file')

--- a/bagit.py
+++ b/bagit.py
@@ -959,6 +959,10 @@ def _configure_logging(opts):
 
 
 def main():
+    if '--version' in sys.argv:
+        print('bagit-python version %s' % VERSION)
+        sys.exit(0)
+
     parser = _make_parser()
     args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     platforms = ['POSIX'],
     test_suite = 'test',
     setup_requires=['setuptools_scm'],
+    tests_require=['mock'],
     install_requires = requirements,
     classifiers = [
         'License :: Public Domain',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = bagit.VERSION
 
 setup(
     name = 'bagit',
-    version = version,
+    use_scm_version=True,
     url = 'https://libraryofcongress.github.io/bagit-python/',
     author = 'Ed Summers',
     author_email = 'ehs@pobox.com',
@@ -39,6 +39,7 @@ setup(
     description = description,
     platforms = ['POSIX'],
     test_suite = 'test',
+    setup_requires=['setuptools_scm'],
     install_requires = requirements,
     classifiers = [
         'License :: Public Domain',

--- a/test.py
+++ b/test.py
@@ -13,11 +13,13 @@ import unittest
 from os.path import join as j
 
 import bagit
+import mock
 
 # don't let < ERROR clutter up test output
 logging.basicConfig(filename="test.log", level=logging.DEBUG)
 
 
+@mock.patch('bagit.VERSION', new='1.5.4')  # This avoids needing to change expected hashes on each release
 class TestSingleProcessValidation(unittest.TestCase):
 
     def setUp(self):
@@ -317,6 +319,7 @@ class TestMultiprocessValidation(TestSingleProcessValidation):
         return super(TestMultiprocessValidation, self).validate(bag, *args, processes=2, **kwargs)
 
 
+@mock.patch('bagit.VERSION', new='1.5.4')  # This avoids needing to change expected hashes on each release
 class TestBag(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This reuses the Git tags to manage version numbers