### PR TITLE
Added Completeness Check, Addresses #87

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -501,7 +501,7 @@ class Bag(object):
     def has_oxum(self):
         return 'Payload-Oxum' in self.info
 
-    def validate(self, processes=1, fast=False):
+    def validate(self, processes=1, fast=False, completeness=False):
         """Checks the structure and contents are valid.
 
         If you supply the parameter fast=True the Payload-Oxum (if present) will
@@ -519,13 +519,13 @@ class Bag(object):
 
         return True
 
-    def is_valid(self, fast=False):
+    def is_valid(self, fast=False, completeness=False):
         """Returns validation success or failure as boolean.
         Optional fast parameter passed directly to validate().
         """
 
         try:
-            self.validate(fast=fast)
+            self.validate(fast=fast, completeness=completeness)
         except BagError:
             return False
 
@@ -1297,6 +1297,10 @@ def _make_parser():
                         help=_('Modify --validate behaviour to only test whether the bag directory'
                                ' has the number of files and total size specified in Payload-Oxum'
                                ' without performing checksum validation to detect corruption.'))
+    parser.add_argument('--completeness', action='store_true',
+                        help=_('Modify --validate behaviour to test whether the bag directory'
+                               ' has the expected payload specified in the checksum manifests'
+                               ' without performing checksum validation to detect corruption.'))
 
     checksum_args = parser.add_argument_group(
         _('Checksum Algorithms'),
@@ -1361,7 +1365,8 @@ def main():
             try:
                 bag = Bag(bag_dir)
                 # validate throws a BagError or BagValidationError
-                bag.validate(processes=args.processes, fast=args.fast)
+                bag.validate(processes=args.processes, fast=args.fast,
+                    completeness=args.completeness)
                 if args.fast:
                     LOGGER.info(_("%s valid according to Payload-Oxum"), bag_dir)
                 else:

--- a/bagit.py
+++ b/bagit.py
@@ -994,9 +994,6 @@ def _calculate_file_hashes(full_path, f_hashers):
     """
     LOGGER.info(_("Verifying checksum for file %s"), full_path)
 
-    if not os.path.exists(full_path):
-        raise BagValidationError(_("File %s does not exist") % full_path)
-
     try:
         with open(full_path, 'rb') as f:
             while True:

--- a/bagit.py
+++ b/bagit.py
@@ -648,7 +648,6 @@ class Bag(object):
 
         # Perform the fast file count + size check so we can fail early:
         self._validate_oxum()
-        self._validate_oxum()
 
         if fast:
             return

--- a/bagit.py
+++ b/bagit.py
@@ -501,7 +501,7 @@ class Bag(object):
     def has_oxum(self):
         return 'Payload-Oxum' in self.info
 
-    def validate(self, processes=1, fast=False, completeness=False):
+    def validate(self, processes=1, fast=False, completeness_only=False):
         """Checks the structure and contents are valid.
 
         If you supply the parameter fast=True the Payload-Oxum (if present) will
@@ -516,17 +516,17 @@ class Bag(object):
         self.validate_fetch()
 
         self._validate_contents(processes=processes, fast=fast,
-            completeness=completeness)
+            completeness_only=completeness_only)
 
         return True
 
-    def is_valid(self, fast=False, completeness=False):
+    def is_valid(self, fast=False, completeness_only=False):
         """Returns validation success or failure as boolean.
         Optional fast parameter passed directly to validate().
         """
 
         try:
-            self.validate(fast=fast, completeness=completeness)
+            self.validate(fast=fast, completeness_only=completeness_only)
         except BagError:
             return False
 
@@ -642,17 +642,17 @@ class Bag(object):
                 raise BagError(_('Malformed URL in fetch.txt: %s') % url)
 
     def _validate_contents(self, processes=1, fast=False,
-        completeness=False):
+                           completeness_only=False):
         if fast and not self.has_oxum():
             raise BagValidationError(_('Fast validation requires bag-info.txt to include Payload-Oxum'))
 
         # Perform the fast file count + size check so we can fail early:
         self._validate_oxum()
 
-        if completeness:
+        if completeness_only:
             self._validate_completeness()
 
-        if not fast and not completeness:
+        if not fast and not completeness_only:
             self._validate_completeness()
             # Now perform the full file hashing process:
             self._validate_entries(processes)
@@ -1312,7 +1312,7 @@ def _make_parser():
                         help=_('Modify --validate behaviour to only test whether the bag directory'
                                ' has the number of files and total size specified in Payload-Oxum'
                                ' without performing checksum validation to detect corruption.'))
-    parser.add_argument('--completeness', action='store_true',
+    parser.add_argument('--completeness-only', action='store_true',
                         help=_('Modify --validate behaviour to test whether the bag directory'
                                ' has the expected payload specified in the checksum manifests'
                                ' without performing checksum validation to detect corruption.'))
@@ -1381,7 +1381,7 @@ def main():
                 bag = Bag(bag_dir)
                 # validate throws a BagError or BagValidationError
                 bag.validate(processes=args.processes, fast=args.fast,
-                             completeness=args.completeness)
+                             completeness_only=args.completeness-only)
                 if args.fast:
                     LOGGER.info(_("%s valid according to Payload-Oxum"), bag_dir)
                 else:

--- a/bagit.py
+++ b/bagit.py
@@ -648,14 +648,17 @@ class Bag(object):
 
         # Perform the fast file count + size check so we can fail early:
         self._validate_oxum()
+        self._validate_oxum()
+
+        if fast:
+            return
+
+        self._validate_completeness()
 
         if completeness_only:
-            self._validate_completeness()
+            return
 
-        if not fast and not completeness_only:
-            self._validate_completeness()
-            # Now perform the full file hashing process:
-            self._validate_entries(processes)
+        self._validate_entries(processes)
 
     def _validate_oxum(self):
         oxum = self.info.get('Payload-Oxum')

--- a/bagit.py
+++ b/bagit.py
@@ -1381,7 +1381,7 @@ def main():
                 bag = Bag(bag_dir)
                 # validate throws a BagError or BagValidationError
                 bag.validate(processes=args.processes, fast=args.fast,
-                    completeness=args.completeness)
+                             completeness=args.completeness)
                 if args.fast:
                     LOGGER.info(_("%s valid according to Payload-Oxum"), bag_dir)
                 else:

--- a/test.py
+++ b/test.py
@@ -161,9 +161,37 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
         with open(readme, "w") as r:
             r.write(txt)
 
-        extra_file = j(self.tmpdir, "data", "extra")
-        with open(extra_file, "w") as ef:
-            ef.write('foo')
+        bag = bagit.Bag(self.tmpdir)
+        got_exception = False
+
+        try:
+            self.validate(bag)
+        except bagit.BagValidationError as e:
+            got_exception = True
+
+            exc_str = str(e)
+            self.assertIn('data/README md5 validation failed: expected="8e2af7a0143c7b8f4de0b3fc90f27354" found="fd41543285d17e7c29cd953f5cf5b955"',
+                          exc_str)
+            self.assertEqual(len(e.details), 1)
+
+            readme_error = e.details[0]
+            self.assertEqual('data/README md5 validation failed: expected="8e2af7a0143c7b8f4de0b3fc90f27354" found="fd41543285d17e7c29cd953f5cf5b955"',
+                             str(readme_error))
+            self.assertIsInstance(readme_error, bagit.ChecksumMismatch)
+            self.assertEqual(readme_error.algorithm, 'md5')
+            self.assertEqual(readme_error.path, 'data/README')
+            self.assertEqual(readme_error.expected, '8e2af7a0143c7b8f4de0b3fc90f27354')
+            self.assertEqual(readme_error.found, 'fd41543285d17e7c29cd953f5cf5b955')
+
+        if not got_exception:
+            self.fail("didn't get BagValidationError")
+
+    def test_validation_completeness_error_details(self):
+        bag = bagit.make_bag(self.tmpdir, checksums=['md5'], bag_info={'Bagging-Date': '1970-01-01'})
+
+        old_path = j(self.tmpdir, "data", "README")
+        new_path = j(self.tmpdir, "data", "extra")
+        os.rename(old_path, new_path)
 
         # remove the bag-info.txt which contains the oxum to force a full
         # check of the manifest
@@ -179,12 +207,9 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
 
             exc_str = str(e)
             self.assertIn("Bag validation failed: bag-info.txt exists in manifest but was not found on filesystem", exc_str)
+            self.assertIn("data/README exists in manifest but was not found on filesystem", exc_str)
             self.assertIn("data/extra exists on filesystem but is not in the manifest", exc_str)
-            self.assertIn('data/README md5 validation failed: expected="8e2af7a0143c7b8f4de0b3fc90f27354" found="fd41543285d17e7c29cd953f5cf5b955"',
-                          exc_str)
-            self.assertIn('bag-info.txt md5 validation failed: expected="87297199b1dbd8dac6d63f604ba2f288" found="File %s does not exist"' % j(self.tmpdir, "bag-info.txt"),
-                          exc_str)
-            self.assertEqual(len(e.details), 4)
+            self.assertEqual(len(e.details), 3)
 
             error = e.details[0]
             self.assertEqual(str(error), "bag-info.txt exists in manifest but was not found on filesystem")
@@ -192,30 +217,15 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
             self.assertEqual(error.path, "bag-info.txt")
 
             error = e.details[1]
+            self.assertEqual(str(error), "data/README exists in manifest but was not found on filesystem")
+            self.assertTrue(error, bagit.FileMissing)
+            self.assertEqual(error.path, "data/README")
+
+            error = e.details[2]
             self.assertEqual(str(error), "data/extra exists on filesystem but is not in the manifest")
             self.assertTrue(error, bagit.UnexpectedFile)
             self.assertEqual(error.path, "data/extra")
 
-            if e.details[2].path == 'data/README':
-                readme_error = e.details[2]
-                baginfo_error = e.details[3]
-            else:
-                readme_error = e.details[3]
-                baginfo_error = e.details[2]
-            self.assertEqual('data/README md5 validation failed: expected="8e2af7a0143c7b8f4de0b3fc90f27354" found="fd41543285d17e7c29cd953f5cf5b955"',
-                             str(readme_error))
-            self.assertIsInstance(readme_error, bagit.ChecksumMismatch)
-            self.assertEqual(readme_error.algorithm, 'md5')
-            self.assertEqual(readme_error.path, 'data/README')
-            self.assertEqual(readme_error.expected, '8e2af7a0143c7b8f4de0b3fc90f27354')
-            self.assertEqual(readme_error.found, 'fd41543285d17e7c29cd953f5cf5b955')
-
-            # cannot test full value of baginfo error as it contains random name for tmp dir
-            self.assertIn("bag-info.txt does not exist", str(baginfo_error))
-            self.assertIsInstance(baginfo_error, bagit.ChecksumMismatch)
-            self.assertEqual(baginfo_error.algorithm, 'md5')
-            self.assertEqual(baginfo_error.path, 'bag-info.txt')
-            self.assertIn("bag-info.txt does not exist", baginfo_error.found)
         if not got_exception:
             self.fail("didn't get BagValidationError")
 

--- a/test.py
+++ b/test.py
@@ -107,7 +107,7 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
         self.assertRaises(bagit.BagValidationError, self.validate, bag)
         # fast doesn't catch the flipped bit, since oxsum is the same
         self.assertTrue(self.validate(bag, fast=True))
-        self.assertTrue(self.validate(bag, completeness=True))
+        self.assertTrue(self.validate(bag, completeness_only=True))
 
     def test_validate_fast(self):
         bag = bagit.make_bag(self.tmpdir)
@@ -124,7 +124,7 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
         bag = bagit.Bag(self.tmpdir)
         self.assertTrue(self.validate(bag, fast=True))
         self.assertRaises(bagit.BagValidationError, self.validate, bag,
-            completeness=True)
+            completeness_only=True)
 
     def test_validate_fast_without_oxum(self):
         bag = bagit.make_bag(self.tmpdir)

--- a/test.py
+++ b/test.py
@@ -107,6 +107,7 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
         self.assertRaises(bagit.BagValidationError, self.validate, bag)
         # fast doesn't catch the flipped bit, since oxsum is the same
         self.assertTrue(self.validate(bag, fast=True))
+        self.assertTrue(self.validate(bag, completeness=True))
 
     def test_validate_fast(self):
         bag = bagit.make_bag(self.tmpdir)

--- a/test.py
+++ b/test.py
@@ -206,20 +206,26 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
             got_exception = True
 
             exc_str = str(e)
-            self.assertIn("Bag validation failed: bag-info.txt exists in manifest but was not found on filesystem", exc_str)
+            self.assertIn("Bag validation failed: ", exc_str)
+            self.assertIn("bag-info.txt exists in manifest but was not found on filesystem", exc_str)
             self.assertIn("data/README exists in manifest but was not found on filesystem", exc_str)
             self.assertIn("data/extra exists on filesystem but is not in the manifest", exc_str)
             self.assertEqual(len(e.details), 3)
 
-            error = e.details[0]
-            self.assertEqual(str(error), "bag-info.txt exists in manifest but was not found on filesystem")
-            self.assertIsInstance(error, bagit.FileMissing)
-            self.assertEqual(error.path, "bag-info.txt")
+            if e.details[0].path == "bag-info.txt":
+                baginfo_error = e.details[0]
+                readme_error = e.details[1]
+            else:
+                baginfo_error = e.details[1]
+                readme_error = e.details[0]
 
-            error = e.details[1]
-            self.assertEqual(str(error), "data/README exists in manifest but was not found on filesystem")
-            self.assertTrue(error, bagit.FileMissing)
-            self.assertEqual(error.path, "data/README")
+            self.assertEqual(str(baginfo_error), "bag-info.txt exists in manifest but was not found on filesystem")
+            self.assertIsInstance(baginfo_error, bagit.FileMissing)
+            self.assertEqual(baginfo_error.path, "bag-info.txt")
+
+            self.assertEqual(str(readme_error), "data/README exists in manifest but was not found on filesystem")
+            self.assertIsInstance(readme_error, bagit.FileMissing)
+            self.assertEqual(readme_error.path, "data/README")
 
             error = e.details[2]
             self.assertEqual(str(error), "data/extra exists on filesystem but is not in the manifest")

--- a/test.py
+++ b/test.py
@@ -115,6 +115,15 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
                     "2478433644_2839c5e8b8_o_d.jpg"))
         self.assertRaises(bagit.BagValidationError, self.validate, bag, fast=True)
 
+    def test_validate_completeness(self):
+        bag = bagit.make_bag(self.tmpdir)
+        os.remove(j(self.tmpdir, "data", "README"))
+        with open(j(self.tmpdir, "data", "extra_file"), "w") as ef:
+            ef.write("foo")
+        bag = bagit.Bag(self.tmpdir)
+        self.assertRaises(bagit.BagValidationError, self.validate, bag,
+            completeness=True)
+
     def test_validate_fast_without_oxum(self):
         bag = bagit.make_bag(self.tmpdir)
         os.remove(j(self.tmpdir, "bag-info.txt"))

--- a/test.py
+++ b/test.py
@@ -123,8 +123,10 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
         os.rename(old_path, new_path)
         bag = bagit.Bag(self.tmpdir)
         self.assertTrue(self.validate(bag, fast=True))
-        self.assertRaises(bagit.BagValidationError, self.validate, bag,
-            completeness_only=True)
+        with mock.patch.object(bag, '_validate_entries') as m:
+            self.assertRaises(bagit.BagValidationError, self.validate, bag,
+                              completeness_only=True)
+            self.assertEqual(m.call_count, 0)
 
     def test_validate_fast_without_oxum(self):
         bag = bagit.make_bag(self.tmpdir)

--- a/test.py
+++ b/test.py
@@ -118,10 +118,11 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
 
     def test_validate_completeness(self):
         bag = bagit.make_bag(self.tmpdir)
-        os.remove(j(self.tmpdir, "data", "README"))
-        with open(j(self.tmpdir, "data", "extra_file"), "w") as ef:
-            ef.write("foo")
+        old_path = j(self.tmpdir, "data", "README")
+        new_path = j(self.tmpdir, "data", "extra_file")
+        os.rename(old_path, new_path)
         bag = bagit.Bag(self.tmpdir)
+        self.assertTrue(self.validate(bag, fast=True))
         self.assertRaises(bagit.BagValidationError, self.validate, bag,
             completeness=True)
 


### PR DESCRIPTION
This PR addresses https://github.com/LibraryOfCongress/bagit-python/issues/87

It separates the logic for completeness checking and hash validation into separate methods, and adds a CLI argument for checking completeness.

The changes have a larger change on validation behavior. If a bag is incomplete, hashes will not be calculated. This fits with my workflow when I need to fix bags or request retransfers, but I thought the change should be highlighted.

It also introduces some awkwardness in cli arguments. `--fast` does not include completeness checking. In the future it might be better to have the following arguments:
`--validate --oxum` = oxum check
`--validate --completeness` = completeness check
`--validate --fast` = completeness and oxum check
`--validate` = completeness, oxum, and hash check
But I didn't want to change existing behaviors with this PR