### PR TITLE
Allow bag in-place on empty directories.

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -1144,6 +1144,10 @@ def make_manifests(data_dir, processes, algorithms=DEFAULT_CHECKSUMS, encoding='
     byte_value_set = set(total_bytes.values())
     file_count_set = set(num_files.values())
 
+    # allow a bag with an empty payload
+    if not (len(byte_value_set) and len(file_count_set)):
+        return 0, 0
+
     if len(file_count_set) != 1:
         raise RuntimeError(_('Expected the same number of files for each checksum'))
 

--- a/bagit.py
+++ b/bagit.py
@@ -1145,7 +1145,7 @@ def make_manifests(data_dir, processes, algorithms=DEFAULT_CHECKSUMS, encoding='
     file_count_set = set(num_files.values())
 
     # allow a bag with an empty payload
-    if not (len(byte_value_set) and len(file_count_set)):
+    if not byte_value_set and not file_count_set:
         return 0, 0
 
     if len(file_count_set) != 1:

--- a/test.py
+++ b/test.py
@@ -516,6 +516,22 @@ class TestBag(SelfCleaningTestCase):
     def test_make_bag_unknown_algorithm(self):
         self.assertRaises(ValueError, bagit.make_bag, self.tmpdir, checksum=['not-really-a-name'])
 
+    def test_make_bag_with_empty_directory(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            bagit.make_bag(tmpdir)
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_make_bag_with_empty_directory_tree(self):
+        tmpdir = tempfile.mkdtemp()
+        path = j(tmpdir, "test1", "test2")
+        try:
+            os.makedirs(path)
+            bagit.make_bag(tmpdir)
+        finally:
+            shutil.rmtree(tmpdir)
+
     def test_make_bag_with_bogus_directory(self):
         bogus_directory = os.path.realpath('this-directory-does-not-exist')
 


### PR DESCRIPTION
As of the 1.6.x release series, it is no longer possible to create a bag in-place from an empty directory or directory path that does not contain any payload files.  This worked in 1.5.4 and previous versions and feels like a regression.  
 
For example:
```sh
mkdir bag
bagit ./bag/
```
Yields:
```
2017-12-12 22:14:24,032 - INFO - Creating bag for directory /home/mdarcy/bag
2017-12-12 22:14:24,032 - INFO - Creating data directory
2017-12-12 22:14:24,033 - INFO - Moving data to /home/mdarcy/bag/tmpMP6HXC/data
2017-12-12 22:14:24,033 - INFO - Moving /home/mdarcy/bag/tmpMP6HXC to data
2017-12-12 22:14:24,033 - INFO - Using 1 processes to generate manifests: sha256, sha512
2017-12-12 22:14:24,033 - ERROR - An error occurred creating a bag in /home/mdarcy/bag
Traceback (most recent call last):
  File "/usr/bin/bagit.py", line 207, in make_bag
    encoding=encoding)
  File "/usr/bin/bagit.py", line 1148, in make_manifests
    raise RuntimeError(_('Expected the same number of files for each checksum'))
RuntimeError: Expected the same number of files for each checksum
2017-12-12 22:14:24,033 - ERROR - Failed to create bag in ./bag/: Expected the same number of files for each checksum
Traceback (most recent call last):
  File "/usr/bin/bagit.py", line 1419, in main
    checksums=args.checksums)
  File "/usr/bin/bagit.py", line 207, in make_bag
    encoding=encoding)
  File "/usr/bin/bagit.py", line 1148, in make_manifests
    raise RuntimeError(_('Expected the same number of files for each checksum'))
RuntimeError: Expected the same number of files for each checksum
```

The following error checking logic in `make_manifests` causes this:
```
    if len(file_count_set) != 1:
        raise RuntimeError(_('Expected the same number of files for each checksum'))

    if len(byte_value_set) != 1:
        raise RuntimeError(_('Expected the same number of bytes for each checksums'))
```

In our application, we make use of the ability to create a bag in-place without payload files in order to create entirely "holey" bags where all payload files are referenced via fetch.txt.  We do this by first creating a empty bag with no payload as a placeholder, and then later create/update the bag manifests with the respective file checkums from our fetch.txt entries.  

We think that just as an empty directory is a *valid* directory (although arguably not very useful), so should a bag without any payload be.  As long as the manifests don't contain any entries that reference the empty directory(ies), then the bag is still spec-compliant.

This PR adds code to test if the payload is empty and bypass the set-based error check in such a case.  It restores functionality from previous versions of `bagit-python` which, in our opinion, is useful and relatively harmless.

If this behavior is to be intentionally removed from 1.6.x and onward, then it might be worth clarifying the exception handling a bit so that a user can better understand why this exception is being thrown in the specific "empty bag" case.