### PR TITLE
Fix for self.algorithms duplication issue in _load_manifests.

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -564,7 +564,8 @@ class Bag(object):
             else:
                 search = "manifest-"
             alg = os.path.basename(manifest_filename).replace(search, "").replace(".txt", "")
-            self.algorithms.append(alg)
+            if alg not in self.algorithms:
+                self.algorithms.append(alg)
 
             with open_text_file(manifest_filename, 'r', encoding=self.encoding) as manifest_file:
                 if manifest_file.encoding.startswith('UTF'):


### PR DESCRIPTION
When the `bag._load_manifests` function loops looking for `tagmanifest-` and `manifest-` files to determine the checksum algorithms currently in use, it calls `self.algorithms.append(alg)`, which generates duplicate algorithm identifiers in `self.algorithms`; one set for the `tagmanifest-` files and a duplicate set for the `manifest-` files.  

Additionally, the more calls to `_load_manifests` that are made on a given bag instance, the more the list grows.  Calling `bag.save` causes this list to grow for every invocation, since at the end of the function `self._load_manifests` is called in order to reload the modified manifests.  This also causes the `bag.save` function to invoke `_make_tagmanifest_file` unnecessarily for every duplicate list entry.  You can see this behavior in action during the unit test function `test_save_manifests`. 

The one-liner fix in this PR just checks for the existence of `alg` in `self.algorithms` before performing the append.  Alternatively, I suppose `self.algorithms` could just be converted to (or wrapped with) a `set`, which is probably more pythonic.