### PR TITLE
assign values to argument namespace instead of parser

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -1522,7 +1522,7 @@ def _make_parser():
     metadata_args = parser.add_argument_group(_("Optional Bag Metadata"))
     for header in STANDARD_BAG_INFO_HEADERS:
         metadata_args.add_argument(
-            "--%s" % header.lower(), type=str, action=BagHeaderAction
+            "--%s" % header.lower(), type=str, action=BagHeaderAction, default=argparse.SUPPRESS
         )
 
     parser.add_argument(

--- a/bagit.py
+++ b/bagit.py
@@ -1442,15 +1442,18 @@ else:
 
 class BagArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
-        self.bag_info = {}
         argparse.ArgumentParser.__init__(self, *args, **kwargs)
 
 
 class BagHeaderAction(argparse.Action):
-    def __call__(self, parser, _, values, option_string=None):
+    def __call__(self, parser, namespace, values, option_string=None):
         opt = option_string.lstrip("--")
         opt_caps = "-".join([o.capitalize() for o in opt.split("-")])
         parser.bag_info[opt_caps] = values
+        try:
+            namespace.bag_info[opt_caps] = values
+        except AttributeError:
+            namespace.bag_info = {opt_caps: values}
 
 
 def _make_parser():
@@ -1593,7 +1596,7 @@ def main():
             try:
                 make_bag(
                     bag_dir,
-                    bag_info=parser.bag_info,
+                    bag_info=args.bag_info,
                     processes=args.processes,
                     checksums=args.checksums,
                 )

--- a/bagit.py
+++ b/bagit.py
@@ -1443,17 +1443,14 @@ else:
 class BagArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
         argparse.ArgumentParser.__init__(self, *args, **kwargs)
+        self.set_defaults(bag_info={})
 
 
 class BagHeaderAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         opt = option_string.lstrip("--")
         opt_caps = "-".join([o.capitalize() for o in opt.split("-")])
-        parser.bag_info[opt_caps] = values
-        try:
-            namespace.bag_info[opt_caps] = values
-        except AttributeError:
-            namespace.bag_info = {opt_caps: values}
+        namespace.bag_info[opt_caps] = values
 
 
 def _make_parser():


### PR DESCRIPTION
Currently, metadata items are assigned to a dict that is stored as an attribute of the argument parser. The proper solution would be to assign the dict to the argument namespace, which is also the way the Python docs suggest.

Also, the generation of default values directly on the argument namespace is suppressed to not litter it with `None` values.