### PR TITLE
Links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 MANIFEST
 bagit.egg-info
 .idea
+.eggs
+*.log

--- a/test.py
+++ b/test.py
@@ -1110,12 +1110,26 @@ class TestFetch(SelfCleaningTestCase):
             self.tmpdir
         )
 
-    def test_bag_symlink_allowed(self):
+    def test_bag_symlink_file(self):
         src = j(os.path.dirname(__file__), "README.rst")
         dst = j(self.tmpdir, "README.rst")
         os.symlink(src, dst)
         bag = bagit.make_bag(self.tmpdir, follow_links=True)
         self.assertTrue(bag.validate())
+
+    def test_symlink_directory_ignored(self):
+        src = j(os.path.dirname(__file__), 'test-data', 'si')
+        dst = j(self.tmpdir, "si-again")
+        os.symlink(src, dst)
+        bag = bagit.make_bag(self.tmpdir)
+        self.assertEqual(len(bag.entries), 15)
+
+    def test_symlink_directory_followed(self):
+        src = j(os.path.dirname(__file__), 'test-data', 'si')
+        dst = j(self.tmpdir, "si-again")
+        os.symlink(src, dst)
+        bag = bagit.make_bag(self.tmpdir, follow_links=True)
+        self.assertEqual(len(bag.entries), 17)
 
 class TestUtils(unittest.TestCase):
     def setUp(self):

--- a/test.py
+++ b/test.py
@@ -1099,6 +1099,23 @@ class TestFetch(SelfCleaningTestCase):
 
         self.assertEqual(expected_msg, str(cm.exception))
 
+    def test_bag_symlink_is_dangerous(self):
+        src = j(os.path.dirname(__file__), "README.rst")
+        dst = j(self.tmpdir, "README.rst")
+        os.symlink(src, dst)
+        self.assertRaisesRegex(
+            bagit.BagError,
+            'Path "data/README.rst" in manifest ".*?" is unsafe',
+            bagit.make_bag,
+            self.tmpdir
+        )
+
+    def test_bag_symlink_allowed(self):
+        src = j(os.path.dirname(__file__), "README.rst")
+        dst = j(self.tmpdir, "README.rst")
+        os.symlink(src, dst)
+        bag = bagit.make_bag(self.tmpdir, follow_links=True)
+        self.assertTrue(bag.validate())
 
 class TestUtils(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Currently if you attempt to bag a directory that contains symbolic links bagit.py happily creates the bag, but the manifests will not include the linked files or directories.

`bagit.py --validate` will say this bag is valid, because the manifests don't mention the linked content, and the code that walks the filesystem during validation ignores links.

However when you are looking at the filesystem you can see there is content present that is not in the manifest. This seems to be contrary to 3.A.4:

> For BagIt 1.0, every payload file MUST be listed in every payload manifest.

This PR includes changes to support following symbolic links when creating and validating bags:

    bagit.py --follow-links mydir
    bagit.py --validate --follow-links mydir

I think an argument could be made that follow links should be the default. I'm thinking of situations where bags are quite large and may use symlinks to manage large payload files/directories.

Is this a crazy idea?