### PR TITLE
travis: Run tests on 16.04 for Python 3.7, 3.8-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+dist: xenial
+sudo: required
 python:
  - "2.7"
  - "3.6"


### PR DESCRIPTION
With this change, tests on Travis will run on 16.04 containers instead of 14.04 (for which 3.7 and 3.8-dev seem unavailable).

c.f. https://travis-ci.org/kba/bagit-python/builds/464906319

BTW The coveralls setup appears broken, the configuration file has been removed from the repo and there is an error Travis:

```
Submitting coverage to coveralls.io...
Coverage submitted!
Couldn't find a repository matching this job.
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.7.1/bin/coveralls", line 11, in <module>
    sys.exit(main())
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/coveralls/cli.py", line 80, in main
    log.info(result['url'])
KeyError: 'url'
```