### PR TITLE
Add support for --wrap option

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -1236,14 +1236,25 @@ def _make_tag_file(bag_info_path, bag_info, line_length):
             for txt in values:
                 txt = force_unicode(txt)
                 if line_length > 1:
-                    # Need to account for the length of the tag name. This
-                    # adds an initial space, then removes it below.
-                    txt = '\n'.join(textwrap.wrap(txt, width=line_length,
-                                                  initial_indent=' '*(len(h) + 2),
-                                                  break_long_words=False,
-                                                  break_on_hyphens=False,
-                                                  subsequent_indent=' '))
-                    txt = txt[len(h) + 2:]
+                    # Account for colon & space written after the property name.
+                    prop_width = len(h) + 2
+                    first_break = prop_width + len(txt.split(None, 1)[0])
+                    if line_length <= first_break:
+                        # Start value on the next line.
+                        txt = '\n'.join(textwrap.wrap(txt, width=line_length,
+                                                      break_long_words=False,
+                                                      break_on_hyphens=False,
+                                                      initial_indent='\n ',
+                                                      subsequent_indent=' '))
+                    else:
+                        # Account for tag name by temporarily adding a leading
+                        # space before calling wrap(), then removing the space.
+                        txt = '\n'.join(textwrap.wrap(txt, width=line_length,
+                                                      break_long_words=False,
+                                                      break_on_hyphens=False,
+                                                      initial_indent=' '*prop_width,
+                                                      subsequent_indent=' '))
+                        txt = txt[prop_width:]
                 else:
                     txt = re.sub(r"\n|\r|(\r\n)", "", txt)
                 f.write("%s: %s\n" % (h, txt))

--- a/bagit.py
+++ b/bagit.py
@@ -139,7 +139,7 @@ UNICODE_BYTE_ORDER_MARK = "\uFEFF"
 
 def make_bag(
     bag_dir, bag_info=None, processes=1, checksums=None, checksum=None,
-    encoding="utf-8", line_length=0
+    encoding="utf-8", tag_wrap_column=0
 ):
     """
     Convert a given directory into a bag. You can pass in arbitrary
@@ -258,7 +258,7 @@ def make_bag(
                 )
 
             bag_info["Payload-Oxum"] = "%s.%s" % (total_bytes, total_files)
-            _make_tag_file("bag-info.txt", bag_info, line_length)
+            _make_tag_file("bag-info.txt", bag_info, tag_wrap_column)
 
             for c in checksums:
                 _make_tagmanifest_file(c, bag_dir, encoding="utf-8")
@@ -452,7 +452,7 @@ class Bag(object):
             if key.startswith("data" + os.sep)
         )
 
-    def save(self, processes=1, manifests=False, line_length=0):
+    def save(self, processes=1, manifests=False, tag_wrap_column=0):
         """
         save will persist any changes that have been made to the bag
         metadata (self.info).
@@ -467,8 +467,8 @@ class Bag(object):
         recalculating checksums use the processes parameter.
 
         If you want long tag values to be wrapped by breaking long strings at
-        whitespace characters, set line_length to a value greater than 0. An
-        integer value greater than 0 causes line-wrapping to be performed on
+        whitespace characters, set tag_wrap_column to a value greater than 0.
+        An integer value greater than 0 causes line-wrapping to be performed on
         a best-effort basis to limit line lengths to the given value.
         """
         # Error checking
@@ -521,7 +521,7 @@ class Bag(object):
             LOGGER.info(_("Updating Payload-Oxum in %s"), self.tag_file_name)
             self.info["Payload-Oxum"] = "%s.%s" % (total_bytes, total_files)
 
-        _make_tag_file(self.tag_file_name, self.info, line_length)
+        _make_tag_file(self.tag_file_name, self.info, tag_wrap_column)
 
         # Update tag-manifest for changes to manifest & bag-info files
         for alg in self.algorithms:
@@ -1226,7 +1226,7 @@ def _parse_tags(tag_file):
         yield (tag_name, tag_value.strip())
 
 
-def _make_tag_file(bag_info_path, bag_info, line_length):
+def _make_tag_file(bag_info_path, bag_info, tag_wrap_column):
     headers = sorted(bag_info.keys())
     with open_text_file(bag_info_path, "w") as f:
         for h in headers:
@@ -1234,30 +1234,37 @@ def _make_tag_file(bag_info_path, bag_info, line_length):
             if not isinstance(values, list):
                 values = [values]
             for txt in values:
-                txt = force_unicode(txt)
-                if line_length > 1:
-                    # Account for colon & space written after the property name.
-                    prop_width = len(h) + 2
-                    first_break = prop_width + len(txt.split(None, 1)[0])
-                    if line_length <= first_break:
-                        # Start value on the next line.
-                        txt = '\n'.join(textwrap.wrap(txt, width=line_length,
-                                                      break_long_words=False,
-                                                      break_on_hyphens=False,
-                                                      initial_indent='\n ',
-                                                      subsequent_indent=' '))
-                    else:
-                        # Account for tag name by temporarily adding a leading
-                        # space before calling wrap(), then removing the space.
-                        txt = '\n'.join(textwrap.wrap(txt, width=line_length,
-                                                      break_long_words=False,
-                                                      break_on_hyphens=False,
-                                                      initial_indent=' '*prop_width,
-                                                      subsequent_indent=' '))
-                        txt = txt[prop_width:]
-                else:
-                    txt = re.sub(r"\n|\r|(\r\n)", "", txt)
+                txt = _format_tag_value(h, txt, tag_wrap_column)
                 f.write("%s: %s\n" % (h, txt))
+
+
+def _format_tag_value(header, txt, tag_wrap_column):
+    txt = force_unicode(txt)
+    if tag_wrap_column > 1:
+        # Account for colon & space written after the property name.
+        prop_width = len(header) + 2
+        # If the wrap column falls in the middle of the first word of the
+        # value, start on the next line. This avoids a very long first line.
+        first_break = prop_width + len(txt.split(None, 1)[0])
+        if tag_wrap_column <= first_break:
+            # Start value on the next line.
+            txt = '\n'.join(textwrap.wrap(txt, initial_indent='\n ',
+                                          width=tag_wrap_column,
+                                          break_long_words=False,
+                                          break_on_hyphens=False,
+                                          subsequent_indent=' '))
+        else:
+            # Account for tag name by temporarily adding a leading space
+            # before calling wrap(), then removing the space later below.
+            txt = '\n'.join(textwrap.wrap(txt, initial_indent=' '*prop_width,
+                                          width=tag_wrap_column,
+                                          break_long_words=False,
+                                          break_on_hyphens=False,
+                                          subsequent_indent=' '))
+            txt = txt[prop_width:]
+    else:
+        txt = re.sub(r"\n|\r|(\r\n)", "", txt)
+    return txt
 
 
 def make_manifests(data_dir, processes, algorithms=DEFAULT_CHECKSUMS, encoding="utf-8"):
@@ -1528,9 +1535,9 @@ def _make_parser():
         ),
     )
     parser.add_argument(
-        "--wrap",
+        "--wrap-tags",
         type=int,
-        dest="line_length",
+        dest="tag_wrap_column",
         default=0,
         help=_(
             "Limit line lengths in the tag file (bag-info.txt) by"
@@ -1635,7 +1642,7 @@ def main():
                     bag_info=args.bag_info,
                     processes=args.processes,
                     checksums=args.checksums,
-                    line_length=args.line_length,
+                    tag_wrap_column=args.tag_wrap_column,
                 )
             except Exception as exc:
                 LOGGER.error(

--- a/bagit.py
+++ b/bagit.py
@@ -14,6 +14,7 @@ import re
 import signal
 import sys
 import tempfile
+import textwrap
 import unicodedata
 import warnings
 from collections import defaultdict
@@ -137,7 +138,8 @@ UNICODE_BYTE_ORDER_MARK = "\uFEFF"
 
 
 def make_bag(
-    bag_dir, bag_info=None, processes=1, checksums=None, checksum=None, encoding="utf-8"
+    bag_dir, bag_info=None, processes=1, checksums=None, checksum=None,
+    encoding="utf-8", line_length=0
 ):
     """
     Convert a given directory into a bag. You can pass in arbitrary
@@ -256,7 +258,7 @@ def make_bag(
                 )
 
             bag_info["Payload-Oxum"] = "%s.%s" % (total_bytes, total_files)
-            _make_tag_file("bag-info.txt", bag_info)
+            _make_tag_file("bag-info.txt", bag_info, line_length)
 
             for c in checksums:
                 _make_tagmanifest_file(c, bag_dir, encoding="utf-8")
@@ -450,7 +452,7 @@ class Bag(object):
             if key.startswith("data" + os.sep)
         )
 
-    def save(self, processes=1, manifests=False):
+    def save(self, processes=1, manifests=False, line_length=0):
         """
         save will persist any changes that have been made to the bag
         metadata (self.info).
@@ -463,6 +465,11 @@ class Bag(object):
 
         If you want to control the number of processes that are used when
         recalculating checksums use the processes parameter.
+
+        If you want long tag values to be wrapped by breaking long strings at
+        whitespace characters, set line_length to a value greater than 0. An
+        integer value greater than 0 causes line-wrapping to be performed on
+        a best-effort basis to limit line lengths to the given value.
         """
         # Error checking
         if not self.path:
@@ -514,7 +521,7 @@ class Bag(object):
             LOGGER.info(_("Updating Payload-Oxum in %s"), self.tag_file_name)
             self.info["Payload-Oxum"] = "%s.%s" % (total_bytes, total_files)
 
-        _make_tag_file(self.tag_file_name, self.info)
+        _make_tag_file(self.tag_file_name, self.info, line_length)
 
         # Update tag-manifest for changes to manifest & bag-info files
         for alg in self.algorithms:
@@ -1219,7 +1226,7 @@ def _parse_tags(tag_file):
         yield (tag_name, tag_value.strip())
 
 
-def _make_tag_file(bag_info_path, bag_info):
+def _make_tag_file(bag_info_path, bag_info, line_length):
     headers = sorted(bag_info.keys())
     with open_text_file(bag_info_path, "w") as f:
         for h in headers:
@@ -1227,8 +1234,18 @@ def _make_tag_file(bag_info_path, bag_info):
             if not isinstance(values, list):
                 values = [values]
             for txt in values:
-                # strip CR, LF and CRLF so they don't mess up the tag file
-                txt = re.sub(r"\n|\r|(\r\n)", "", force_unicode(txt))
+                txt = force_unicode(txt)
+                if line_length > 1:
+                    # Need to account for the length of the tag name. This
+                    # adds an initial space, then removes it below.
+                    txt = '\n'.join(textwrap.wrap(txt, width=line_length,
+                                                  initial_indent=' '*(len(h) + 2),
+                                                  break_long_words=False,
+                                                  break_on_hyphens=False,
+                                                  subsequent_indent=' '))
+                    txt = txt[len(h) + 2:]
+                else:
+                    txt = re.sub(r"\n|\r|(\r\n)", "", txt)
                 f.write("%s: %s\n" % (h, txt))
 
 
@@ -1499,6 +1516,17 @@ def _make_parser():
             " without performing checksum validation to detect corruption."
         ),
     )
+    parser.add_argument(
+        "--wrap",
+        type=int,
+        dest="line_length",
+        default=0,
+        help=_(
+            "Limit line lengths in the tag file (bag-info.txt) by"
+            " wrapping long values and indenting subsequent lines with a"
+            " space character. (Default: don't.)"
+        ),
+    )
 
     checksum_args = parser.add_argument_group(
         _("Checksum Algorithms"),
@@ -1596,6 +1624,7 @@ def main():
                     bag_info=args.bag_info,
                     processes=args.processes,
                     checksums=args.checksums,
+                    line_length=args.line_length,
                 )
             except Exception as exc:
                 LOGGER.error(

--- a/test.py
+++ b/test.py
@@ -127,14 +127,14 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
         os.remove(j(self.tmpdir, "data", "loc", "2478433644_2839c5e8b8_o_d.jpg"))
         self.assertRaises(bagit.BagValidationError, self.validate, bag, fast=True)
 
-    def test_validate_wrapped_tag_lines_shorter(self):
+    def test_validate_wrapped_tag_lines_short(self):
         info = {"External-Description":
                 ('BagIt is a set of hierarchical file layout conventions'
                  ' designed to support storage and transfer of arbitrary'
                  ' digital content.  A bag consists of a directory containing'
                  ' the payload files and other accompanying metadata files'
                  ' known as "tag" files.')}
-        bag = bagit.make_bag(self.tmpdir, bag_info=info, line_length=30)
+        bag = bagit.make_bag(self.tmpdir, bag_info=info, line_length=18)
         self.assertEqual(self.validate(bag, fast=True), True)
         os.remove(j(self.tmpdir, "data", "loc", "2478433644_2839c5e8b8_o_d.jpg"))
         self.assertRaises(bagit.BagValidationError, self.validate, bag, fast=True)

--- a/test.py
+++ b/test.py
@@ -115,6 +115,30 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
         os.remove(j(self.tmpdir, "data", "loc", "2478433644_2839c5e8b8_o_d.jpg"))
         self.assertRaises(bagit.BagValidationError, self.validate, bag, fast=True)
 
+    def test_validate_wrapped_tag_lines(self):
+        info = {"External-Description":
+                ('BagIt is a set of hierarchical file layout conventions'
+                 ' designed to support storage and transfer of arbitrary'
+                 ' digital content.  A bag consists of a directory containing'
+                 ' the payload files and other accompanying metadata files'
+                 ' known as "tag" files.')}
+        bag = bagit.make_bag(self.tmpdir, bag_info=info, line_length=79)
+        self.assertEqual(self.validate(bag, fast=True), True)
+        os.remove(j(self.tmpdir, "data", "loc", "2478433644_2839c5e8b8_o_d.jpg"))
+        self.assertRaises(bagit.BagValidationError, self.validate, bag, fast=True)
+
+    def test_validate_wrapped_tag_lines_shorter(self):
+        info = {"External-Description":
+                ('BagIt is a set of hierarchical file layout conventions'
+                 ' designed to support storage and transfer of arbitrary'
+                 ' digital content.  A bag consists of a directory containing'
+                 ' the payload files and other accompanying metadata files'
+                 ' known as "tag" files.')}
+        bag = bagit.make_bag(self.tmpdir, bag_info=info, line_length=30)
+        self.assertEqual(self.validate(bag, fast=True), True)
+        os.remove(j(self.tmpdir, "data", "loc", "2478433644_2839c5e8b8_o_d.jpg"))
+        self.assertRaises(bagit.BagValidationError, self.validate, bag, fast=True)
+
     def test_validate_completeness(self):
         bag = bagit.make_bag(self.tmpdir)
         old_path = j(self.tmpdir, "data", "README")

--- a/test.py
+++ b/test.py
@@ -122,7 +122,7 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
                  ' digital content.  A bag consists of a directory containing'
                  ' the payload files and other accompanying metadata files'
                  ' known as "tag" files.')}
-        bag = bagit.make_bag(self.tmpdir, bag_info=info, line_length=79)
+        bag = bagit.make_bag(self.tmpdir, bag_info=info, tag_wrap_column=79)
         self.assertEqual(self.validate(bag, fast=True), True)
         os.remove(j(self.tmpdir, "data", "loc", "2478433644_2839c5e8b8_o_d.jpg"))
         self.assertRaises(bagit.BagValidationError, self.validate, bag, fast=True)
@@ -134,7 +134,7 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
                  ' digital content.  A bag consists of a directory containing'
                  ' the payload files and other accompanying metadata files'
                  ' known as "tag" files.')}
-        bag = bagit.make_bag(self.tmpdir, bag_info=info, line_length=18)
+        bag = bagit.make_bag(self.tmpdir, bag_info=info, tag_wrap_column=18)
         self.assertEqual(self.validate(bag, fast=True), True)
         os.remove(j(self.tmpdir, "data", "loc", "2478433644_2839c5e8b8_o_d.jpg"))
         self.assertRaises(bagit.BagValidationError, self.validate, bag, fast=True)


### PR DESCRIPTION
The previous behavior of `bagit.py` was asymmetrical with respect to how
it treated long tag lines: it would handle folded lines when reading
the `bag-info.txt` file, but it would not fold long lines when writing
long tag values into `bag-info.txt`.  This was hardwired into the
function `_make_tag_file()`, which explicitly stripped line endings from
tag values before writing them.

Section 2.2.2 of the BagIt spec (https://tools.ietf.org/html/rfc8493)
states the following:

>   It is RECOMMENDED that lines not exceed 79 characters in length.
>   Long values MAY be continued onto the next line by inserting a LF,
>   CR, or CRLF, and then indenting the next line with one or more linear
>   white space characters (spaces or tabs).  Except for linebreaks, such
>   padding does not form part of the value.

This PR adds a new command-line option, `--wrap`, and a new
parameter named `line_width` to the functions `make_bag()` and
`save()`, to make it possible to follow the recommendation. The
default value is 0, which means don't wrap (which is the original
behavior).  An integer value greater than 0 causes line-wrapping to be
performed on a best-effort basis to limit line lengths to the given
value.

This addresses issue #126.