### PR TITLE
remove non-unicode en-dash from comment

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -1021,7 +1021,7 @@ def posix_multiprocessing_worker_initializer():
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
-# The Unicode normalization form used here doesn't matter – all we care about
+# The Unicode normalization form used here doesn't matter - all we care about
 # is consistency since the input value will be preserved:
 
 


### PR DESCRIPTION
The en-dash (`–`) caused a `UnicodeDecodeError` for me. It should not since the `# *-* coding` comment is set at the top of the file but it still did for me while recording a terminal session with `asciinema`.

As far as I can see (grepping `[^\x00-\x7F]`) this is the only instance of a non-ascii char in the source.