### PR TITLE
Allow bagging to destination

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -20,7 +20,7 @@ import warnings
 from collections import defaultdict
 from datetime import date
 from functools import partial
-from os.path import abspath, isdir, isfile, join
+from os.path import abspath, isdir, isfile, join, realpath
 
 from pkg_resources import DistributionNotFound, get_distribution
 
@@ -165,17 +165,17 @@ def make_bag(
 
     if dest_dir:
         bag_name = os.path.basename(bag_dir)
-        dest_dir = os.path.abspath(os.path.join(dest_dir, bag_name))
+        dest_dir = realpath(os.path.join(dest_dir, bag_name))
         if not os.path.isdir(dest_dir):
             os.makedirs(dest_dir)
         else:
             raise RuntimeError(_("The following directory already exists:\n%s"), dest_dir)
     else:
-        dest_dir = os.path.abspath(bag_dir)
+        dest_dir = realpath(bag_dir)
 
-    source_dir = os.path.abspath(bag_dir)
+    source_dir = realpath(bag_dir)
 
-    cwd = os.path.abspath(os.path.curdir)
+    cwd = realpath(os.path.curdir)
 
     if cwd.startswith(source_dir) and cwd != source_dir:
         raise RuntimeError(
@@ -189,7 +189,7 @@ def make_bag(
         raise RuntimeError(_("Bag source directory %s does not exist") % bag_dir)
         
     # FIXME: we should do the permissions checks before changing directories
-    old_dir = os.path.abspath(os.path.curdir)
+    old_dir = realpath(os.path.curdir)
 
     try: 
         # TODO: These two checks are currently redundant since an unreadable directory will also
@@ -228,13 +228,11 @@ def make_bag(
             # FIXME: if we calculate full paths we won't need to deal with changing directories
             os.chdir(source_dir)
             cwd = os.getcwd()
-            temp_data = tempfile.mkdtemp(dir=dest_dir)
-            # getcwd resolves symlinks, dest_dir used abspath, which doesn't
-            temp_data = os.path.realpath(temp_data)
+            temp_data = realpath(tempfile.mkdtemp(dir=dest_dir))
 
             if source_dir == dest_dir:
                 for f in os.listdir("."):
-                    if os.path.abspath(f) == temp_data:
+                    if realpath(f) == temp_data:
                         continue
                     new_f = os.path.join(temp_data, f)
                     LOGGER.info(
@@ -338,7 +336,7 @@ class Bag(object):
 
         self.algorithms = []
         self.tag_file_name = None
-        self.path = abspath(path)
+        self.path = realpath(path)
         if path:
             # if path ends in a path separator, strip it off
             if path[-1] == os.sep:
@@ -542,7 +540,7 @@ class Bag(object):
             )
 
         # Change working directory to bag directory so helper functions work
-        old_dir = os.path.abspath(os.path.curdir)
+        old_dir = realpath(os.path.curdir)
         os.chdir(self.path)
 
         # Generate new manifest files

--- a/bagit.py
+++ b/bagit.py
@@ -1651,7 +1651,7 @@ def main():
                     bag_info=args.bag_info,
                     processes=args.processes,
                     checksums=args.checksums,
-                    dest_dir=args.destination
+                    dest_dir=args.dest_dir
                 )
             except Exception as exc:
                 if args.dest_dir:

--- a/bagit.py
+++ b/bagit.py
@@ -168,8 +168,8 @@ def make_bag(
         dest_dir = realpath(os.path.join(dest_dir, bag_name))
         if not os.path.isdir(dest_dir):
             os.makedirs(dest_dir)
-        else:
-            raise RuntimeError(_("The following directory already exists:\n%s"), dest_dir)
+        elif len(os.listdir(dest_dir)) > 0:
+            raise RuntimeError(_("The following directory already exists and contains files:\n%s"), dest_dir)
     else:
         dest_dir = realpath(bag_dir)
 

--- a/bagit.py
+++ b/bagit.py
@@ -10,6 +10,7 @@ import hashlib
 import logging
 import multiprocessing
 import os
+import random
 import re
 import signal
 import shutil
@@ -228,9 +229,9 @@ def make_bag(
             # FIXME: if we calculate full paths we won't need to deal with changing directories
             os.chdir(source_dir)
             cwd = os.getcwd()
-            temp_data = realpath(tempfile.mkdtemp(dir=dest_dir))
 
             if source_dir == dest_dir:
+                temp_data = realpath(tempfile.mkdtemp(dir=dest_dir))
                 for f in os.listdir("."):
                     if realpath(f) == temp_data:
                         continue
@@ -241,16 +242,12 @@ def make_bag(
                     )
                     os.rename(f, new_f)
             else:
-                for f in os.listdir("."):
-                    new_f = os.path.join(temp_data, f)
-                    LOGGER.info(
-                        _("Copying %(source)s to %(destination)s"),
-                        {"source": f, "destination": new_f},
-                    )
-                    if os.path.isdir(f):
-                        shutil.copytree(f, new_f)
-                    else:
-                        shutil.copy(f, new_f)
+                temp_data_name = ''.join(random.choice('abcdefghijklmnopqrstuvwxyz0123456789') for _ in range(6))
+                temp_data = os.path.join(dest_dir, temp_data_name)
+                while os.path.isdir(temp_data):
+                    temp_data = temp_data + random.choice('abcdefghijklmnopqrstuvwxyz0123456789')
+                
+                shutil.copytree(".", temp_data)
 
             LOGGER.info(
                 _("Moving %(source)s to %(destination)s"),
@@ -270,7 +267,8 @@ def make_bag(
                 )
             else:
                 total_bytes, total_files = make_manifests(
-                    ".", processes, algorithms=checksums, encoding=encoding, dest_dir=dest_dir, rel_path="data"
+                    ".", processes, algorithms=checksums, encoding=encoding,
+                    dest_dir=dest_dir, rel_path="data"
                 )
 
             os.chdir(dest_dir)

--- a/bagit.py
+++ b/bagit.py
@@ -169,7 +169,7 @@ def make_bag(
         dest_dir = realpath(os.path.join(dest_dir, bag_name))
         if not os.path.isdir(dest_dir):
             os.makedirs(dest_dir)
-        elif len(os.listdir(dest_dir)) > 0:
+        elif os.stat(dest_dir).st_nlink > 0:
             raise RuntimeError(_("The following directory already exists and contains files:\n%s"), dest_dir)
     else:
         dest_dir = realpath(bag_dir)

--- a/test.py
+++ b/test.py
@@ -129,8 +129,11 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
 
     def test_make_bag_bad_destination(self):
         tmp_dir_out = tempfile.mkdtemp(prefix='bagit-test-dest')
-        subdir = os.path.basename(self.tmpdir)
-        os.makedirs(os.path.join(tmp_dir_out, subdir))
+        pre_existing_bag_dir = j(tmp_dir_out, os.path.basename(self.tmpdir))
+        os.makedirs(pre_existing_bag_dir)
+        pre_existing_file = j(pre_existing_bag_dir, '.DS_Store')
+        with open(pre_existing_file, 'w') as f:
+            f.write('ugh')
 
         self.assertRaises(
             RuntimeError, bagit.make_bag,

--- a/test.py
+++ b/test.py
@@ -43,7 +43,7 @@ class SelfCleaningTestCase(unittest.TestCase):
         self.starting_directory = (
             os.getcwd()
         )  # FIXME: remove this after we stop changing directories in bagit.py
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = os.path.realpath(tempfile.mkdtemp())
         if os.path.isdir(self.tmpdir):
             shutil.rmtree(self.tmpdir)
         shutil.copytree("test-data", self.tmpdir)

--- a/test.py
+++ b/test.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import codecs
 import datetime
+import filecmp
 import hashlib
 import logging
 import os
@@ -95,6 +96,48 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
         self.assertTrue(os.path.isfile(j(self.tmpdir, "manifest-sha256.txt")))
         # check valid with three manifests
         self.assertTrue(self.validate(bag, fast=True))
+
+    def test_make_bag_with_destination(self):
+        tmp_dir_out = tempfile.mkdtemp(prefix='bagit-test-')
+        dest_dir = j(tmp_dir_out, 'test-dest')
+        bag = bagit.make_bag(
+            self.tmpdir, dest_dir=dest_dir, checksums=['sha256', 'sha512']
+        )
+        subdir = os.path.basename(self.tmpdir)
+        self.assertTrue(os.path.isfile(j(dest_dir, subdir, 'manifest-sha256.txt')))
+        self.assertTrue(os.path.isfile(j(dest_dir, subdir, 'manifest-sha512.txt')))
+        self.assertTrue(self.validate(bag, fast=True))
+        diff = filecmp.dircmp(self.tmpdir, os.path.join(dest_dir, subdir, 'data'))
+        self.assertTrue(len(diff.left_only+diff.right_only) == 0)
+        shutil.rmtree(tmp_dir_out)
+
+    def test_make_bags_with_destinations(self):
+        dest = tempfile.mkdtemp(prefix='bagit-test-dest-')
+        src_par = tempfile.mkdtemp(prefix='bagit-test-src-')
+        srcs = tuple(os.path.join(src_par, '%04d' % i) for i in range(10))
+        subdirs = tuple(os.path.relpath(src, src_par) for src in srcs)
+        for src in srcs:
+            shutil.copytree('test-data', src)
+            bag = bagit.make_bag(src, dest_dir=dest, checksum=['sha256'])
+        self.assertTrue(tuple(sorted(os.listdir(dest))) == subdirs)
+        for src, subdir in zip(srcs, subdirs):
+            diff = filecmp.dircmp(src, os.path.join(dest, subdir, 'data'))
+            self.assertTrue(len(diff.left_only+diff.right_only) == 0)
+        self.assertTrue(self.validate(bag))
+        shutil.rmtree(src_par)
+        shutil.rmtree(dest)
+
+    def test_make_bag_bad_destination(self):
+        tmp_dir_out = tempfile.mkdtemp(prefix='bagit-test-dest')
+        subdir = os.path.basename(self.tmpdir)
+        os.makedirs(os.path.join(tmp_dir_out, subdir))
+
+        self.assertRaises(
+            RuntimeError, bagit.make_bag,
+            self.tmpdir, dest_dir=tmp_dir_out, checksum=['sha256', 'sha512']
+        )
+
+        shutil.rmtree(tmp_dir_out)
 
     def test_validate_flipped_bit(self):
         bag = bagit.make_bag(self.tmpdir)

--- a/test.py
+++ b/test.py
@@ -622,7 +622,7 @@ class TestBag(SelfCleaningTestCase):
             bagit.make_bag(bogus_directory)
 
         self.assertEqual(
-            "Bag directory %s does not exist" % bogus_directory,
+            "Bag source directory %s does not exist" % bogus_directory,
             str(error_catcher.exception),
         )
 

--- a/test.py
+++ b/test.py
@@ -141,6 +141,13 @@ class TestSingleProcessValidation(SelfCleaningTestCase):
 
         shutil.rmtree(tmp_dir_out)
 
+    def test_make_bag_parentdir(self): 
+        os.chdir(j(self.tmpdir, 'loc'))
+        self.assertRaises(
+            RuntimeError, bagit.make_bag,
+            self.tmpdir, checksum=['sha256', 'sha512']
+        )
+
     def test_validate_flipped_bit(self):
         bag = bagit.make_bag(self.tmpdir)
         readme = j(self.tmpdir, "data", "README")


### PR DESCRIPTION
Based on @runderwood #92, but reimplemented within the current codebase to address #32 and #136 

Major difference, this places every source within its own bag rather than combining bag, e.g.
`bagit.py --destination foo/ --directory bar/ baz/`
will create 
```
foo
├──bar
│  ├── bag-info.txt
│  ├── ...
└──baz
   ├── bag-info.txt
   ├── ...
```
which mirrors current behavior that bagit.py --directory bar/ baz/ creates
```
./
├──bar
│  ├── bag-info.txt
│  ├── ...
└──baz
   ├── bag-info.txt
   ├── ...
```