### PR TITLE
is_valid() method can now pass an optional processes parameter to validate()

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -610,13 +610,13 @@ class Bag(object):
 
         return True
 
-    def is_valid(self, fast=False, completeness_only=False):
+    def is_valid(self, processes=1, fast=False, completeness_only=False):
         """Returns validation success or failure as boolean.
-        Optional fast parameter passed directly to validate().
+        Optional processes and fast parameters passed directly to validate().
         """
 
         try:
-            self.validate(fast=fast, completeness_only=completeness_only)
+            self.validate(processes=processes, fast=fast, completeness_only=completeness_only)
         except BagError:
             return False
 


### PR DESCRIPTION
I'm not sure if this wasn't included for some reason I'm not seeing, but this lets you use multiple cores when validating with the `is_valid()` method as a library. You can then: `if bag.is_valid(processes=4):`