### PR TITLE
Fix SyntaxWarning with is against literal

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -631,7 +631,7 @@ class Bag(object):
             manifests += list(self.tagmanifest_files())
 
         for manifest_filename in manifests:
-            if not manifest_filename.find("tagmanifest-") is -1:
+            if manifest_filename.find("tagmanifest-") != -1:
                 search = "tagmanifest-"
             else:
                 search = "manifest-"


### PR DESCRIPTION
Trivial fix to remove warning with current pythons:

```
bagit-python> python --version
Python 3.8.1
bagit-python> python test.py
.../bagit.py:634: SyntaxWarning: "is not" with a literal. Did you mean "!="?  if not manifest_filename.find("tagmanifest-") is -1:
```