### PR TITLE
Allow fetch.txt with file URLs to validate

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -772,7 +772,9 @@ class Bag(object):
             # well formed:
             parsed_url = urlparse(url)
 
-            if not all((parsed_url.scheme, parsed_url.netloc)):
+            # each parsed url must resolve to a scheme and point to a netloc
+            # if the scheme is file, netloc is not necessary
+            if not (all((parsed_url.scheme, parsed_url.netloc)) or parsed_url.scheme == "file"):
                 raise BagError(_("Malformed URL in fetch.txt: %s") % url)
 
     def _validate_contents(self, processes=1, fast=False, completeness_only=False):


### PR DESCRIPTION
It looks like it passes all the tests (`python setup.py test` doesn't return any error) and it also succeds to validate the bag I added in https://github.com/LibraryOfCongress/bagit-conformance-suite/pull/14 with this kind of entries in the fetch.txt:

```
file:///home/avivace/cern/example_bags/source/sachiel.png 42000 sachiel.png
```

It should effectively fix https://github.com/LibraryOfCongress/bagit-python/issues/153.

The fetch.txt validation now passes when:

- The URL scheme resolves to "file" after parsing (no value need for netloc in this case)
- The schema resolves to anything AND the netloc has a value too

```
if not (all((parsed_url.scheme, parsed_url.netloc)) or parsed_url.scheme == "file"):
```