### PR TITLE
move to importlib

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -21,7 +21,7 @@ from datetime import date
 from functools import partial
 from os.path import abspath, isdir, isfile, join
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version
 
 try:
     from urllib.parse import urlparse
@@ -48,9 +48,8 @@ MODULE_NAME = "bagit" if __name__ == "__main__" else __name__
 
 LOGGER = logging.getLogger(MODULE_NAME)
 
-try:
-    VERSION = get_distribution(MODULE_NAME).version
-except DistributionNotFound:
+VERSION = version(MODULE_NAME)
+if not VERSION:
     VERSION = "0.0.dev0"
 
 PROJECT_URL = "https://github.com/LibraryOfCongress/bagit-python"


### PR DESCRIPTION
small change to move away from the deprecated `pkg_resources`

`importlib.metadata` is not supported in 3.7, which is still supported by bagit-python.

The library also doesn't have an exception class but it can return `None`.