### PR TITLE
Move from pkg resources to importlib

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -21,7 +21,10 @@ from datetime import date
 from functools import partial
 from os.path import abspath, isdir, isfile, join
 
-from importlib.metadata import version
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
 
 try:
     from urllib.parse import urlparse

--- a/bagit.py
+++ b/bagit.py
@@ -21,7 +21,7 @@ from datetime import date
 from functools import partial
 from os.path import abspath, isdir, isfile, join
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version
 
 try:
     from urllib.parse import urlparse
@@ -48,9 +48,8 @@ MODULE_NAME = "bagit" if __name__ == "__main__" else __name__
 
 LOGGER = logging.getLogger(MODULE_NAME)
 
-try:
-    VERSION = get_distribution(MODULE_NAME).version
-except DistributionNotFound:
+VERSION = version(MODULE_NAME)
+if not VERSION:
     VERSION = "0.0.dev0"
 
 PROJECT_URL = "https://github.com/LibraryOfCongress/bagit-python"

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     platforms=["POSIX"],
     test_suite="test",
     setup_requires=["setuptools_scm"],
+    install_requires=["importlib_metadata ; python_version < '3.8'"],
     tests_require=tests_require,
     classifiers=[
         "License :: Public Domain",


### PR DESCRIPTION
Continuation of #170, adds a fallback to `importlib_metadata` for earlier versions.

Very much would appreciate a new release with thius, importing `pkg_resources` is expensive and `setuptools` will not be available at runtime by default in newer python versions.