### PR TITLE
Update bagit.py

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -781,10 +781,9 @@ class Bag(object):
                 _("Fast validation requires bag-info.txt to include Payload-Oxum")
             )
 
-        # Perform the fast file count + size check so we can fail early:
-        self._validate_oxum()
-
         if fast:
+            # Perform the fast file count + size check so we can fail early:
+            self._validate_oxum()
             return
 
         self._validate_completeness()


### PR DESCRIPTION
Fixing validation bug - oxum validation was outside the if fast condition, so validation was *always* defaulting to fast