### PR TITLE
Fix README to remove syntax not supported by PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,6 @@
 bagit-python
 ============
 
-|Build Status| |Coverage Status|
-
 bagit is a Python library and command line utility for working with
 `BagIt <http://purl.org/net/bagit>`__ style packages.
 


### PR DESCRIPTION
Remove unsupported ReST extensions from README
