### PR TITLE
Wait for pool to finish in validation

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -882,13 +882,12 @@ class Bag(object):
             if processes == 1:
                 hash_results = [_calc_hashes(i) for i in args]
             else:
-                try:
-                    pool = multiprocessing.Pool(
-                        processes if processes else None, initializer=worker_init
-                    )
-                    hash_results = pool.map(_calc_hashes, args)
-                finally:
-                    pool.terminate()
+                pool = multiprocessing.Pool(
+                    processes if processes else None, initializer=worker_init
+                )
+                hash_results = pool.map(_calc_hashes, args)
+                pool.close()
+                pool.join()
 
         # Any unhandled exceptions are probably fatal
         except:

--- a/test.py
+++ b/test.py
@@ -458,6 +458,15 @@ class TestMultiprocessValidation(TestSingleProcessValidation):
             bag, *args, processes=2, **kwargs
         )
 
+    @mock.patch("bagit.multiprocessing.Pool")
+    def test_validate_pool_error(self, pool):
+        # Simulate the Pool constructor raising a RuntimeError.
+        pool.side_effect = RuntimeError
+        bag = bagit.make_bag(self.tmpdir)
+        # Previously, this raised UnboundLocalError if uninitialized.
+        with self.assertRaises(RuntimeError):
+            self.validate(bag)
+
 
 @mock.patch(
     "bagit.VERSION", new="1.5.4"


### PR DESCRIPTION
This pull request ensures `_validate_entries` uses `pool.close()` and `pool.join()` for proper multiprocessing cleanup, addressing the issues in https://github.com/LibraryOfCongress/bagit-python/issues/173, including avoiding `UnboundLocalError` and ensuring clean shutdown of worker processes.