### PR TITLE
Remove expandvars call in unsafe path check

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -932,8 +932,6 @@ class Bag(object):
             return True
         if os.path.expanduser(path) != path:
             return True
-        if os.path.expandvars(path) != path:
-            return True
         real_path = os.path.realpath(os.path.join(self.path, path))
         real_path = os.path.normpath(real_path)
         bag_path = os.path.realpath(self.path)


### PR DESCRIPTION
Per discussion [here](https://github.com/LibraryOfCongress/bagit-python/issues/152#issuecomment-2704150109), this changeset removes the `expandvars` call in `_path_is_dangerous`.

@acdha Please let me know if this what you have in mind. If not, happy to rework.