### PR TITLE
fix: HTTP icon on gh pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ utility:</p>
 <h2>
 <a name="license" class="anchor" href="#license"><span class="octicon octicon-link"></span></a>License</h2>
 
-<p><a href="http://creativecommons.org/publicdomain/zero/1.0/"><img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" alt="cc0"></a></p>
+<p><a href="https://creativecommons.org/publicdomain/zero/1.0/"><img src="https://licensebuttons.net/p/zero/1.0/88x31.png" alt="Creative Commons CC0 Public Domain"></a></p>
       </section>
       <footer>
         <p>This project is maintained by <a href="https://github.com/LibraryOfCongress">LibraryOfCongress</a></p>


### PR DESCRIPTION
The GH Pages site loads over HTTPS by default which means the CC0 icon will be blocked by browser mixed content policies. This uses a new HTTP URL and also improves the alt text for the icon to be more meaningful.