### PR TITLE
pass `re.sub` flags as kwargs

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -1409,8 +1409,8 @@ def _encode_filename(s):
 
 
 def _decode_filename(s):
-    s = re.sub(r"%0D", "\r", s, re.IGNORECASE)
-    s = re.sub(r"%0A", "\n", s, re.IGNORECASE)
+    s = re.sub(r"%0D", "\r", s, flags=re.IGNORECASE)
+    s = re.sub(r"%0A", "\n", s, flags=re.IGNORECASE)
     return s
 
 


### PR DESCRIPTION
hello :)

making some bags in testing, getting a `DeprecationWarning`:

```
tests/test_validation.py: 81 warnings
  .venv/bin/bagit.py:1412: DeprecationWarning: 'count' is passed as positional argument
    s = re.sub(r"%0D", "\r", s, re.IGNORECASE)

tests/test_validation.py: 81 warnings
  .venv/bin/bagit.py:1413: DeprecationWarning: 'count' is passed as positional argument
    s = re.sub(r"%0A", "\n", s, re.IGNORECASE)
```

looks like the flags are being interpreted as `count`, and we're also being warned that we need to pass extra args as kwargs anyway, so fixed that :)