### PR TITLE
Alternate method of making temp data folder to account for domain-joined windows accounts #193

### DIFF
--- a/bagit.py
+++ b/bagit.py
@@ -214,7 +214,8 @@ def make_bag(
             # FIXME: if we calculate full paths we won't need to deal with changing directories
             os.chdir(bag_dir)
             cwd = os.getcwd()
-            temp_data = tempfile.mkdtemp(dir=cwd)
+            temp_data = os.path.join(cwd, next(tempfile._get_candidate_names()))
+            os.mkdir(temp_data)
 
             for f in os.listdir("."):
                 if os.path.abspath(f) == temp_data:


### PR DESCRIPTION
This is a fix for #193 and uses an alternative method `(os.mkdir`) instead of `tempfile.mkdtemp ` to work correctly with domain-joined windows accounts with regards to permissions. I'm very open to any other methods of working around this issue!