### PR TITLE
Fixes Dockerfile to use uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.11.5-python3.14-trixie
-RUN useradd --user-group bagit-tester
-RUN install -d -o bagit-tester /bagit
+RUN useradd --user-group bagit-tester && \
+    install -d -o bagit-tester /bagit
 WORKDIR /bagit
 COPY pyproject.toml /bagit/pyproject.toml
 COPY .git/ /bagit/.git/
@@ -10,8 +10,12 @@ COPY test.py /bagit/
 COPY test-data /bagit/test-data/
 COPY utils/ /bagit/
 ENV UV_LINK_MODE=copy
-RUN mkdir /home/bagit-tester/ && mkdir /home/bagit-tester/.cache && mkdir /home/bagit-tester/.cache/uv && \
-    apt-get update && apt-get install dos2unix -y && find test-data -name 'README' |xargs dos2unix
-RUN chown bagit-tester /home/bagit-tester/.cache/uv
+RUN mkdir /home/bagit-tester/ && \
+    mkdir /home/bagit-tester/.cache && \
+    mkdir /home/bagit-tester/.cache/uv && \
+    apt-get update && \
+    apt-get install dos2unix -y && \
+    find test-data -name 'README' | xargs dos2unix && \
+    chown bagit-tester /home/bagit-tester/.cache/uv
 USER bagit-tester
 CMD [ "uv", "run", "pytest" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14
+FROM ghcr.io/astral-sh/uv:0.11.5-python3.14-trixie
 RUN useradd --user-group bagit-tester
 RUN install -d -o bagit-tester /bagit
 WORKDIR /bagit
@@ -9,8 +9,9 @@ COPY src/ /bagit/src/
 COPY test.py /bagit/
 COPY test-data /bagit/test-data/
 COPY utils/ /bagit/
-RUN pip install --upgrade pip && pip install uv && uv sync --all-extras
-RUN mkdir /home/bagit-tester/ && mkdir /home/bagit-tester/.cache && mkdir /home/bagit-tester/.cache/uv
+ENV UV_LINK_MODE=copy
+RUN mkdir /home/bagit-tester/ && mkdir /home/bagit-tester/.cache && mkdir /home/bagit-tester/.cache/uv && \
+    apt-get update && apt-get install dos2unix -y && find test-data -name 'README' |xargs dos2unix
 RUN chown bagit-tester /home/bagit-tester/.cache/uv
 USER bagit-tester
 CMD [ "uv", "run", "pytest" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM python:3.11
+FROM python:3.14
 RUN useradd --user-group bagit-tester
 RUN install -d -o bagit-tester /bagit
-USER bagit-tester
 WORKDIR /bagit
+COPY pyproject.toml /bagit/pyproject.toml
 COPY .git/ /bagit/.git/
-COPY *.rst *.py /bagit/
+COPY *.rst /bagit/
+COPY src/ /bagit/src/
+COPY test.py /bagit/
 COPY test-data /bagit/test-data/
-CMD [ "python", "setup.py", "test" ]
+COPY utils/ /bagit/
+RUN pip install --upgrade pip && pip install uv && uv sync --all-extras
+RUN mkdir /home/bagit-tester/ && mkdir /home/bagit-tester/.cache && mkdir /home/bagit-tester/.cache/uv
+RUN chown bagit-tester /home/bagit-tester/.cache/uv
+USER bagit-tester
+CMD [ "uv", "run", "pytest" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.11.5-python3.14-trixie
+FROM ghcr.io/astral-sh/uv:0.11.7-python3.14-trixie
 RUN useradd --user-group bagit-tester && \
     install -d -o bagit-tester /bagit
 WORKDIR /bagit


### PR DESCRIPTION
Dockerfile had setup.py syntax. Now matches readme.rst

This now works as promised
`docker build -t bagit:latest . && docker run -it bagit:latest`