### PR TITLE
fix: remove legacy Ruff configuration options such as target-version and hook ID

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.15.2
       hooks:
-          - id: ruff
+          - id: ruff-check
             args: [--fix, --exit-non-zero-on-fix]
           - id: ruff-format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,6 @@ requires-python = ">= 3.9"
 [project.urls]
 Homepage = "https://libraryofcongress.github.io/bagit-python/"
 
-[tool]
-
-[tool.ruff]
-target-version = "py38"
-
 [tool.isort]
 line_length = 110
 default_section = "THIRDPARTY"


### PR DESCRIPTION
## Description

- Removed the legacy pre-commit Ruff hook ID and updated it to the latest key ID.
- The library supports only Python 3.9 and above, so the old Ruff `target-version` (which pointed to Python 3.8) has been removed. Ruff will now automatically read `requires-python` from `pyproject.toml` and select the possible lower bound `(Python 3.9)`.